### PR TITLE
feat: implement positionals

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --build",
     "prepublishOnly": "tsc --build",
     "test:web": "playwright-test --runner entail 'test/**/*.spec.js'",
-    "test:node": "c8 entail 'test/*.spec.js'",
+    "test:node": "c8 entail 'test/**/*.spec.js'",
     "test": "npm run test:node",
     "coverage": "c8 --reporter=html entail 'test/*.spec.js' && npm_config_yes=true npx st -d coverage -p 8080",
     "check": "tsc --build",

--- a/src/position/base.js
+++ b/src/position/base.js
@@ -1,0 +1,51 @@
+/**
+ * Just a type alias so we can better communicate intended type.
+ * @typedef {number & {Uint8?:{}}} Uint8
+ */
+
+/**
+ * @typedef {readonly [from:Uint8, to:Uint8]} Range
+ * @typedef {readonly [Range, ...Range[]]} Ranges
+ */
+
+/**
+ * Parses a base description string and generates an ordered list of [from, to] ranges.
+ * @param {string} descriptor - A string containing all characters in the base.
+ */
+export const parse = (descriptor) => {
+  // Sort the characters in ascending order of their character codes.
+  let codes = [...new Set(descriptor)]
+    .sort((a, b) => a.charCodeAt(0) - b.charCodeAt(0))
+    .map((char) => char.charCodeAt(0))
+
+  /** @type {Range[]} */
+  let ranges = []
+  let startCharCode = codes[0]
+  let endCharCode = startCharCode
+
+  for (let i = 1; i < codes.length; i++) {
+    let charCode = codes[i]
+
+    // If the character codes are consecutive, extend the current range.
+    if (charCode === endCharCode + 1) {
+      endCharCode = charCode
+    }
+    // If the character codes are not consecutive, start a new range.
+    else {
+      ranges.push([startCharCode, endCharCode])
+      startCharCode = charCode
+      endCharCode = charCode
+    }
+  }
+
+  // Don't forget to push the last range.
+  ranges.push([startCharCode, endCharCode])
+
+  return {
+    min: ranges[0][0],
+    max: ranges[ranges.length - 1][1],
+    codes,
+    /** @type {Ranges} */
+    ranges: /** @type {[Range, ...Range[]]} */ (ranges),
+  }
+}

--- a/src/position/base.js
+++ b/src/position/base.js
@@ -9,8 +9,14 @@
  */
 
 /**
+ * @typedef Base
+ * @property {Uint8[]} codes
+ * @property {Ranges} ranges
+ */
+/**
  * Parses a base description string and generates an ordered list of [from, to] ranges.
  * @param {string} descriptor - A string containing all characters in the base.
+ * @returns {Base}
  */
 export const parse = (descriptor) => {
   // Sort the characters in ascending order of their character codes.
@@ -42,10 +48,20 @@ export const parse = (descriptor) => {
   ranges.push([startCharCode, endCharCode])
 
   return {
-    min: ranges[0][0],
-    max: ranges[ranges.length - 1][1],
     codes,
     /** @type {Ranges} */
     ranges: /** @type {[Range, ...Range[]]} */ (ranges),
   }
 }
+
+/**
+ * @param {Base} base
+ * @returns {Uint8}
+ */
+export const min = ({ codes }) => codes[0]
+
+/**
+ * @param {Base} base
+ * @returns {Uint8}
+ */
+export const max = ({ codes }) => codes[codes.length - 1]

--- a/src/position/digit.js
+++ b/src/position/digit.js
@@ -1,4 +1,4 @@
-import { values } from './iterator.js'
+import { reverse } from './iterator.js'
 import * as Base from './base.js'
 export const EQUAL = Symbol.for('EQUAL')
 export const CONSECUTIVE = Symbol.for('CONSECUTIVE')
@@ -62,7 +62,7 @@ export const decrement = (digit, ranges) => {
   const subsequent = digit - 1
 
   // Iterate over each range in reverse order.
-  for (const [from, to] of values.reverse(ranges)) {
+  for (const [from, to] of reverse.values(ranges)) {
     // If the character is above this range, it must be falling between ranges,
     // so we just round it down to the largest digit in this range.
     if (subsequent > to) {

--- a/src/position/digit.js
+++ b/src/position/digit.js
@@ -1,3 +1,4 @@
+import { entries, values } from './iterator.js'
 import * as Base from './base.js'
 export const EQUAL = Symbol.for('EQUAL')
 export const CONSECUTIVE = Symbol.for('CONSECUTIVE')
@@ -61,8 +62,7 @@ export const decrement = (digit, ranges) => {
   const subsequent = digit - 1
 
   // Iterate over each range in reverse order.
-  for (let i = ranges.length - 1; i >= 0; i--) {
-    const [from, to] = ranges[i]
+  for (const [from, to] of values.reverse(ranges)) {
     // If the character is above this range, it must be falling between ranges,
     // so we just round it down to the largest digit in this range.
     if (subsequent > to) {

--- a/src/position/digit.js
+++ b/src/position/digit.js
@@ -1,4 +1,4 @@
-import { entries, values } from './iterator.js'
+import { values } from './iterator.js'
 import * as Base from './base.js'
 export const EQUAL = Symbol.for('EQUAL')
 export const CONSECUTIVE = Symbol.for('CONSECUTIVE')
@@ -80,63 +80,16 @@ export const decrement = (digit, ranges) => {
 }
 
 /**
- * @template {Base.Uint8} [Digit=Base.Uint8]
- * @param {Digit} digit
- * @param {Base.Ranges<Digit>} ranges
- * @returns {Digit|null}
- */
-export const round = (digit, ranges) => {
-  for (const [low, high] of ranges) {
-    // If digit is below this range we just round it up to the the lower bound.
-    if (digit < low) {
-      return low
-    }
-    // If digit is less then high bound of the range it is within the range and
-    // we return it.
-    else if (digit <= high) {
-      return digit
-    }
-  }
-
-  return null
-}
-
-/**
- * @template {Base.Uint8} [Digit=Base.Uint8]
- * @param {Digit} digit
- * @param {Base.Ranges<Digit>} ranges
- * @returns {Digit|null}
- */
-export const roundDown = (digit, ranges) => {
-  let previous = null
-  for (const [low, high] of ranges) {
-    // If digit is less than or equal to the high bound of the range we round it
-    // down to the low bound of the range.
-    if (digit < low) {
-      if (previous) {
-        return previous
-      } else {
-        return null
-      }
-    } else if (digit <= high) {
-      return digit
-    } else {
-      previous = high
-    }
-  }
-
-  return previous
-}
-
-/**
  * Finds an intermediate digit between the given two with a constraint that
  * it fits passed ranges. Return positive value if the valid intermediate digit
  * exists, otherwise returns a negative of the average of the two digits to
  * signal that it falls out of the given ranges.
  *
+ * @template {Digit} From
+ * @template {Digit} To
  * @template {Base.Uint8} [Digit=Base.Uint8]
- * @param {Digit} from - The first digit for the average calculation.
- * @param {Digit} to - The second digit for the average calculation.
+ * @param {From} from - The first digit for the average calculation.
+ * @param {To} to - The second digit for the average calculation.
  * @param {Base.Ranges<Digit>} ranges - The ranges of valid digit values.
  * @returns {Digit|EQUAL|CONSECUTIVE}
  */

--- a/src/position/digit.js
+++ b/src/position/digit.js
@@ -1,0 +1,147 @@
+/**
+ * @typedef {import('./base.js').Uint8} Uint8
+ * @typedef {import('./base.js').Ranges} Ranges
+ */
+
+/**
+ * Just a type alias so we can better communicate intended type. It is a
+ * negative integer that signals that corresponding Uint8 fall out of bounds.
+ *
+ * @typedef {number & {OutOfBound?:{}}} OutOfBound
+ */
+
+/**
+ * Increments a single digit such that it falls within the given ranges. If
+ * incremented digit falls between ranges it will be rounded up to the smallest
+ * digit in the next range. If incremented digit falls out of bounds it will
+ * return `OutOfBound`.
+ *
+ * @param {Uint8} digit - The digit to increment.
+ * @param {Ranges} ranges - The ranges of valid digit values.
+ * @returns {Uint8|OutOfBound} The incremented digit, or -1 if the digit falls out of bounds.
+ */
+export const increment = (digit, ranges) => {
+  const subsequent = digit + 1
+
+  // Otherwise we go over each range to find the one subsequent digit will fall
+  // into.
+  for (const [from, to] of ranges) {
+    // If character is below this range it must be falling between ranges
+    // so we just round it up to the smallest digit in this range.
+    if (subsequent < from) {
+      return from
+    }
+    // If character is within this range great then we just return it
+    else if (subsequent <= to) {
+      return subsequent
+    }
+    // Otherwise we're going to move on to the next range.
+  }
+
+  // If we got here digit is out of bounds and we return -1 to signal it.
+  return -subsequent
+}
+
+/**
+ * Decrements a single digit within the given ranges. If the decremented digit
+ * falls between ranges it will be rounded down to the largest digit in the
+ * previous range. If the decremented digit falls out of bounds it will return
+ * -
+ *
+ * @param {Uint8} digit - The digit to decrement.
+ * @param {Ranges} ranges - The ranges of valid digit values.
+ * @returns {Uint8|OutOfBound} The decremented digit, or -1 if digit falls out of bounds.
+ */
+export const decrement = (digit, ranges) => {
+  const subsequent = digit - 1
+
+  // Iterate over each range in reverse order.
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const [from, to] = ranges[i]
+    // If the character is above this range, it must be falling between ranges,
+    // so we just round it down to the largest digit in this range.
+    if (subsequent > to) {
+      return to
+    }
+    // If the character is within this range, we just return it.
+    else if (subsequent >= from) {
+      return subsequent
+    }
+    // Otherwise, we're going to move on to the previous range.
+  }
+
+  // If we got here, the digit is out of bounds and we return -1 to signal it.
+  return -subsequent
+}
+
+/**
+ * Finds an intermediate digit between the given two with a constraint that
+ * it fits passed ranges. Return positive value if the valid intermediate digit
+ * exists, otherwise returns a negative of the average of the two digits to
+ * signal that it falls out of the given ranges.
+ *
+ * @param {Uint8} from - The first digit for the average calculation.
+ * @param {Uint8} to - The second digit for the average calculation.
+ * @param {Ranges} ranges - The ranges of valid digit values.
+ * @returns {Uint8|OutOfBound}
+ */
+export const intermediate = (from, to, ranges) => {
+  const [low, high] = from > to ? [to, from] : [from, to]
+  // Calculate the average of the two digits.
+  const intermediate = Math.floor((from + to) / 2)
+
+  // Ensure that the average digit is within the valid ranges.
+  for (const [at, [from, to]] of ranges.entries()) {
+    // If the average digit is below this range we attempt to round up to the
+    // smallest digit in this range. If that falls out of `low..high` bounds we
+    // attempt to round down to the upper bound of the previous range. If that
+    // falls out of bounds also we just return `-1 * average` signaling that no
+    // average can fit the constraints.
+    if (intermediate < from) {
+      const [, upper] = ranges[at - 1] ?? [, -1]
+      // Attempting to round up to the lower bound of the this range.
+      if (from > low && from < high) {
+        return from
+      }
+      // Attempt to round down to the upper bound of the last range.
+      else if (upper > low && upper < high) {
+        return upper
+      }
+      // We will not be able to find a average that falls in our ranges. If the
+      // `upper === low` we return -low, that way caller can tell it does not
+      // satisfy the constraints, but often they would still use `low` as base
+      // and find average in the next segment.
+      else if (upper === low) {
+        return -low
+      }
+      // If rounding down missed the range we attempt the same with rounded up
+      // value.
+      else if (from === high) {
+        return -from
+      }
+      // If both rounding up and down falls out of the range that implies that
+      // both `from` and `to` were between ranges in which case we just return
+      // `-1 * average`. This is a signal that no valid average can be found,
+      // yet caller can still choose to use actual average.
+      else {
+        return -intermediate
+      }
+    }
+
+    // If average is within this range we found it and we simply return.
+    if (intermediate >= from && intermediate <= to) {
+      return intermediate
+    }
+  }
+
+  // If got here `average` is greater than upper bound of our last range. We
+  // attempt to round it down to the upper bound of the last range. If that
+  // falls within `low..high` bounds we return it, otherwise our `low` is
+  // passed the upper bound of the last range and we return `-1 * average`.
+  const max = ranges[ranges.length - 1][1]
+  if (max > low && max < high) {
+    return max
+  } else {
+    return -intermediate
+  }
+}

--- a/src/position/digits.js
+++ b/src/position/digits.js
@@ -1,0 +1,211 @@
+import * as Digit from './digit.js'
+import * as Base from './base.js'
+
+/**
+ * @typedef {import('./base.js').Uint8} Uint8
+ */
+
+/**
+ * These are the supported major zones when incrementing digit between the
+ * zones it will produce a digit in the next zone.
+ */
+export const base62 = Base.parse(
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+)
+
+export const base58 = Base.parse(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+)
+
+/**
+ * @param {Uint8Array} source
+ */
+export const toString = (source) => new TextDecoder().decode(source)
+
+/**
+ * @param {string} source
+ */
+export const fromString = (source) => new TextEncoder().encode(source)
+
+/**
+ * @param {ArrayLike<number>} source
+ */
+export const fromArray = (source) => {
+  const major = new Uint8Array(source.length)
+  major.set(source)
+  return major
+}
+
+/**
+ * Takes an byte array representing position as fixed set of digits and returns
+ * a new byte array with the incremented value. Function ensures that returned
+ * byte array bytes that are in the base62 range, when increment falls out of
+ * the range it will either round up to the next digit that would fit the range
+ * or return null if it is not possible to increment the number further with in
+ * the current byte array capacity.
+ *
+ * @param {Uint8Array} source
+ * @param {Base.Ranges} base
+ */
+export const increment = (source, base) => {
+  // Create a new Digits instance to avoid mutating the original one.
+  let digits = new Uint8Array(source)
+
+  // Iterate over the digits in reverse order (from least significant to most significant).
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = Digit.increment(digits[i], base)
+    // If digit is -1, we have a carry. Otherwise, no carry.
+    if (digit < 0) {
+      // If the digit is already at the maximum value in its range, we have a carry.
+      // Reset the digit to the minimum value in its range.
+      digits[i] = base[0][0]
+    } else {
+      // Otherwise, no carry, so we can break the loop early.
+      digits[i] = digit
+      return digits
+    }
+  }
+
+  // If we have not returned from the loop we are unable to increment the number
+  // further as we are at the maximum capacity in this byte array. It such case
+  // we return null letting the caller know that incrementing is not possible.
+  return null
+  // // If we have not returned from the loop we still have to increment. In such
+  // // case, we need to add a new digit to the end of the byte array to increase
+  // // it's fraction.
+  // let newDigits = new Uint8Array(digits.length + 1)
+  // newDigits.set(digits) // Copies digits into newDigits.
+  // newDigits[digits.length] = source.base[0][0] // Set the new digit to the minimum value in its range.
+
+  // return Digits.new(
+  //   newDigits.buffer,
+  //   newDigits.byteOffset,
+  //   newDigits.length,
+  //   source.base
+  // )
+}
+
+/**
+ * Takes a byte array representing a position as a fixed set of digits and returns
+ * a new byte array with the decremented value. The function ensures that the returned
+ * byte array bytes are in the base62 range. When decrementing falls out of
+ * the range, it will either round down to the previous digit that would fit the range
+ * or return null if it is not possible to decrement the number further with the
+ * current byte array capacity.
+ *
+ * @param {Uint8Array} source
+ * @param {Base.Ranges} base
+ * @returns {Uint8Array|null} The decremented digits as a byte array, or null if decrementing was not possible.
+ */
+export const decrement = (source, base) => {
+  // Create a new Uint8Array instance to avoid mutating the original one.
+  let digits = new Uint8Array(source)
+
+  // Iterate over the digits in reverse order (from least significant to most significant).
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = Digit.decrement(digits[i], base)
+    // If digit is -1, we have a "borrow". Otherwise, no "borrow".
+    if (digit < 0) {
+      // If the digit is already at the minimum value in its range, we have a "borrow".
+      // Reset the digit to the maximum value in its range.
+      digits[i] = base[base.length - 1][1]
+    } else {
+      // Otherwise, no "borrow", so we can break the loop early.
+      digits[i] = digit
+      return digits
+    }
+  }
+
+  // If we have not returned from the loop, we are unable to decrement the number
+  // further as we are at the minimum capacity in this byte array. In such case,
+  // we return null, letting the caller know that decrementing is not possible.
+  return null
+}
+
+export const EQUAL = Symbol.for('EQUAL')
+export const CONSECUTIVE = Symbol.for('CONSECUTIVE')
+
+/**
+ * Computes an average between two digits that would fit given ranges. If both
+ * digits are equal or consecutive it will not be able to derive an average and
+ * will return null. Otherwise, it will return a new byte array with the average
+ * digit. Returned digit may be shorter than the input digits because trailing
+ * `min` values are implied.
+ *
+ * @param {Uint8Array} begin
+ * @param {Uint8Array} end
+ * @param {Base.Ranges} ranges - The ranges of valid digit values.
+ */
+export const intermediate = (begin, end, ranges) => {
+  const min = ranges[0][0] // Minimum value from the ranges
+  const max = ranges[ranges.length - 1][1] // Maximum value from the ranges
+
+  // Copy the digits that are in common at the beginning.
+  const digits = []
+  let offset = 0
+  while ((begin[offset] ?? min) === (end[offset] ?? min)) {
+    digits.push(begin[offset] ?? min)
+    offset++
+  }
+
+  // If we reached the end of the both digits they were equal and their average
+  // is the same as the either of two so we return null to signify that.
+  if (offset === begin.length && offset === end.length) {
+    return EQUAL
+  }
+
+  // If digits aren't equal we determine which one is the greater.
+  const [smaller, greater] =
+    (begin[offset] ?? min) < (end[offset] ?? min) ? [begin, end] : [end, begin]
+
+  // Next we will copy all the digits from the smaller until we find the average
+  // that falls between the smaller and greater.
+  let lower = smaller[offset] ?? min
+  let upper = greater[offset] ?? max
+  let average = Digit.intermediate(lower, upper, ranges)
+  while (average < 0) {
+    digits.push(lower)
+
+    // Smaller might be shorter and all trailing are implicitly min values.
+    lower = smaller[++offset] ?? min
+    // Greater might be longer in which case we use max value in this base
+    // as an upper bound.
+    upper = greater[offset] ?? max
+
+    // Compute next average.
+    average = Digit.intermediate(lower, upper, ranges)
+  }
+
+  // If we found the `average` we can add it to the digits and return the result.
+  // otherwise there is no average between the two digits passed so we return
+  // null.
+  if (average >= 0) {
+    digits.push(average)
+    return new Uint8Array(digits)
+  } else {
+    return CONSECUTIVE
+  }
+}
+
+/**
+ * Removes trailing min values from the given digits.
+ *
+ * @param {Uint8Array} digits
+ * @param {Base.Ranges} ranges - The ranges of valid digit values.
+ * @returns {Uint8Array}
+ */
+export const trim = (digits, ranges) => {
+  const min = ranges[0][0] // Minimum value from the ranges
+  let length = digits.length
+  while (length > 0) {
+    if (digits[length - 1] === min) {
+      length--
+    } else {
+      break
+    }
+  }
+
+  return length === digits.length
+    ? digits
+    : new Uint8Array(digits.buffer, digits.byteOffset, length)
+}

--- a/src/position/digits.js
+++ b/src/position/digits.js
@@ -2,6 +2,7 @@ import * as Digit from './digit.js'
 import * as Base from './base.js'
 import { CONSECUTIVE, EQUAL } from './digit.js'
 export { toBase } from './base.js'
+import { entries } from './iterator.js'
 
 export { CONSECUTIVE, EQUAL } from './digit.js'
 
@@ -78,17 +79,18 @@ export const increment = (source, base) => {
   let digits = new Uint8Array(source)
 
   // Iterate over the digits in reverse order (from least significant to most significant).
-  for (let i = digits.length - 1; i >= 0; i--) {
-    let digit = Digit.increment(digits[i], base)
+  for (const [offset, value] of entries.reverse(digits)) {
+    // for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = Digit.increment(value, base)
     // If digit is -1, we have a carry. Otherwise, no carry.
     if (digit < 0) {
       // If the digit is already at the maximum value in its range, we have a carry.
       // Reset the digit to the minimum value in its range.
-      digits[i] = base[0][0]
+      digits[offset] = base[0][0]
     } else {
-      // Otherwise, no carry, so we can break the loop early.
-      digits[i] = digit
-      return /** @type {T} */ (digits)
+      // Otherwise we found the digit that is consecutive.
+      digits[offset] = digit
+      return /** @type {T} */ (digits.subarray(0, offset + 1))
     }
   }
 
@@ -115,18 +117,19 @@ export const decrement = (source, base) => {
   // Create a new Uint8Array instance to avoid mutating the original one.
   let digits = new Uint8Array(source)
 
-  // Iterate over the digits in reverse order (from least significant to most significant).
-  for (let i = digits.length - 1; i >= 0; i--) {
-    let digit = Digit.decrement(digits[i], base)
+  // Iterate over the digits in reverse order (from least significant to most
+  // significant).
+  for (const [offset, value] of entries.reverse(digits)) {
+    let digit = Digit.decrement(value, base)
     // If digit is -1, we have a "borrow". Otherwise, no "borrow".
     if (digit < 0) {
       // If the digit is already at the minimum value in its range, we have a "borrow".
       // Reset the digit to the maximum value in its range.
-      digits[i] = base[base.length - 1][1]
+      digits[offset] = base[base.length - 1][1]
     } else {
       // Otherwise, no "borrow", so we can break the loop early.
-      digits[i] = digit
-      return /** @type {T} */ (digits)
+      digits[offset] = digit
+      return trim(/** @type {T} */ (digits), base)
     }
   }
 

--- a/src/position/digits.js
+++ b/src/position/digits.js
@@ -209,3 +209,36 @@ export const trim = (digits, ranges) => {
     ? digits
     : new Uint8Array(digits.buffer, digits.byteOffset, length)
 }
+
+const BYTE_SIZE = 256 // The number of unique values a byte can represent.
+
+/**
+ * Converts a byte array to an digit array in a given base.
+ *
+ * @param {Uint8Array} bytes
+ * @param {Base.Base} base
+ */
+export const toBase = (bytes, base) => {
+  let digits = []
+  let carry = 0
+  while (bytes.length > 0) {
+    let remainder = []
+    carry = 0
+    // Process each byte in the input array.
+    for (let byte of bytes) {
+      let acc = byte + carry * BYTE_SIZE
+      carry = acc % base.codes.length
+      // Unshift the quotient to the remainder array to avoid reversing later.
+      remainder.unshift(Math.floor(acc / base.codes.length))
+    }
+    // Unshift the carry value to the baseValues array.
+    digits.unshift(base.codes[carry])
+    // Remove leading zeros from the remainder array.
+    while (remainder.length > 0 && remainder[0] === 0) {
+      remainder.shift()
+    }
+    bytes = Uint8Array.from(remainder)
+  }
+
+  return new Uint8Array(digits)
+}

--- a/src/position/digits.js
+++ b/src/position/digits.js
@@ -53,15 +53,6 @@ export const toString = (source) => new TextDecoder().decode(source)
 export const fromString = (source) => new TextEncoder().encode(source)
 
 /**
- * @param {ArrayLike<Uint8>} source
- */
-export const fromArray = (source) => {
-  const major = new Uint8Array(source.length)
-  major.set(source)
-  return major
-}
-
-/**
  * Takes an byte array representing position as fixed set of digits and returns
  * a new byte array with the incremented value. Function ensures that returned
  * byte array bytes that are in the base62 range, when increment falls out of

--- a/src/position/digits.js
+++ b/src/position/digits.js
@@ -2,7 +2,7 @@ import * as Digit from './digit.js'
 import * as Base from './base.js'
 import { CONSECUTIVE, EQUAL } from './digit.js'
 export { toBase } from './base.js'
-import { entries } from './iterator.js'
+import { reverse } from './iterator.js'
 
 export { CONSECUTIVE, EQUAL } from './digit.js'
 
@@ -70,7 +70,7 @@ export const increment = (source, base) => {
   let digits = new Uint8Array(source)
 
   // Iterate over the digits in reverse order (from least significant to most significant).
-  for (const [offset, value] of entries.reverse(digits)) {
+  for (const [offset, value] of reverse(digits)) {
     // for (let i = digits.length - 1; i >= 0; i--) {
     let digit = Digit.increment(value, base)
     // If digit is -1, we have a carry. Otherwise, no carry.
@@ -110,7 +110,7 @@ export const decrement = (source, base) => {
 
   // Iterate over the digits in reverse order (from least significant to most
   // significant).
-  for (const [offset, value] of entries.reverse(digits)) {
+  for (const [offset, value] of reverse(digits)) {
     let digit = Digit.decrement(value, base)
     // If digit is -1, we have a "borrow". Otherwise, no "borrow".
     if (digit < 0) {

--- a/src/position/iterator.js
+++ b/src/position/iterator.js
@@ -1,0 +1,46 @@
+export const entries = Object.assign(
+  /**
+   * @template T
+   * @param {ArrayLike<T>} source
+   * @returns {Iterable<[number, T]>}
+   */
+  function* entries(source) {
+    for (let offset = 0; offset < source.length; offset++) {
+      yield [offset, source[offset]]
+    }
+  },
+  {
+    /**
+     * @template T
+     * @param {ArrayLike<T>} source
+     */
+    *reverse(source) {
+      for (let offset = source.length - 1; offset >= 0; offset--) {
+        yield [offset, source[offset]]
+      }
+    },
+  }
+)
+
+export const values = Object.assign(
+  /**
+   * @template T
+   * @param {Iterable<T>} source
+   */
+  function* (source) {
+    for (const value of source) {
+      yield value
+    }
+  },
+  {
+    /**
+     * @template T
+     * @param {ArrayLike<T>} source
+     */
+    reverse: function* (source) {
+      for (let offset = source.length - 1; offset >= 0; offset--) {
+        yield source[offset]
+      }
+    },
+  }
+)

--- a/src/position/iterator.js
+++ b/src/position/iterator.js
@@ -1,11 +1,11 @@
-export const entries = Object.assign(
+export const reverse = Object.assign(
   /**
    * @template T
    * @param {ArrayLike<T>} source
    * @returns {Iterable<[number, T]>}
    */
-  function* entries(source) {
-    for (let offset = 0; offset < source.length; offset++) {
+  function* reverse(source) {
+    for (let offset = source.length - 1; offset >= 0; offset--) {
       yield [offset, source[offset]]
     }
   },
@@ -13,31 +13,9 @@ export const entries = Object.assign(
     /**
      * @template T
      * @param {ArrayLike<T>} source
+     * @returns {Iterable<T>}
      */
-    *reverse(source) {
-      for (let offset = source.length - 1; offset >= 0; offset--) {
-        yield [offset, source[offset]]
-      }
-    },
-  }
-)
-
-export const values = Object.assign(
-  /**
-   * @template T
-   * @param {Iterable<T>} source
-   */
-  function* (source) {
-    for (const value of source) {
-      yield value
-    }
-  },
-  {
-    /**
-     * @template T
-     * @param {ArrayLike<T>} source
-     */
-    reverse: function* (source) {
+    *values(source) {
       for (let offset = source.length - 1; offset >= 0; offset--) {
         yield source[offset]
       }

--- a/src/position/lib.js
+++ b/src/position/lib.js
@@ -1,4 +1,6 @@
 import * as Position from './position.js'
+import * as Digits from './digits.js'
+import * as Digit from './digit.js'
 import * as UTF8 from '../utf8.js'
 
 /**
@@ -17,14 +19,25 @@ export const toPosition = (at) => UTF8.toUTF8(at)
 export const fromPosition = (position) => UTF8.fromUTF8(position)
 
 /**
- * @param {Uint8Array} bias
+ * @param {Uint8Array} item
+ * @returns {Uint8Array & Digits.Uint8[]}
+ */
+export const deriveBias = (item) =>
+  /** @type {Uint8Array & Digits.Uint8[]} */ (
+    Digits.toBase(item, Digits.base62)
+  )
+
+/**
+ * @param {Uint8Array} item - Uint8Array representation of the unique item
+ * identifier it could be
+ *
  * @param {object} at
  * @param {At} [at.after]
  * @param {At} [at.before]
  */
-export const insert = (bias, { after, before }) =>
+export const insert = (item, { after, before }) =>
   fromPosition(
-    Position.insert(bias, {
+    Position.insert(deriveBias(item), {
       after: after ? toPosition(after) : undefined,
       before: before ? toPosition(before) : undefined,
     })

--- a/src/position/lib.js
+++ b/src/position/lib.js
@@ -1,7 +1,8 @@
 import * as Position from './position.js'
 import * as Digits from './digits.js'
-import * as Digit from './digit.js'
 import * as UTF8 from '../utf8.js'
+
+export { Position }
 
 /**
  * @typedef {string} At

--- a/src/position/lib.js
+++ b/src/position/lib.js
@@ -1,0 +1,31 @@
+import * as Position from './position.js'
+import * as UTF8 from '../utf8.js'
+
+/**
+ * @typedef {string} At
+ */
+
+/**
+ * @param {string} at
+ */
+export const toPosition = (at) => UTF8.toUTF8(at)
+
+/**
+ * @param {Uint8Array} position
+ * @returns {At}
+ */
+export const fromPosition = (position) => UTF8.fromUTF8(position)
+
+/**
+ * @param {Uint8Array} bias
+ * @param {object} at
+ * @param {At} [at.after]
+ * @param {At} [at.before]
+ */
+export const insert = (bias, { after, before }) =>
+  fromPosition(
+    Position.insert(bias, {
+      after: after ? toPosition(after) : undefined,
+      before: before ? toPosition(before) : undefined,
+    })
+  )

--- a/src/position/major.js
+++ b/src/position/major.js
@@ -1,6 +1,7 @@
 import * as Digit from './digit.js'
 import * as Minor from './minor.js'
 import { base58 as base } from './digits.js'
+import * as Base from './base.js'
 
 import { EQUAL, CONSECUTIVE } from './digits.js'
 
@@ -8,8 +9,8 @@ const [[outerNegative, innerNegative], [innerPositive, outerPositive]] =
   base.ranges
 
 export { base }
-export const MIN = base.min
-export const MAX = base.max
+export const MIN = Base.min(base)
+export const MAX = Base.max(base)
 
 export const min = new Uint8Array([MIN, ...new Uint8Array(MIN).fill(Minor.MIN)])
 export const max = new Uint8Array([MAX, ...new Uint8Array(MAX).fill(Minor.MAX)])

--- a/src/position/major.js
+++ b/src/position/major.js
@@ -27,8 +27,8 @@ export { EQUAL, CONSECUTIVE }
  * [65...90,  97..122]
  * ```
  *
- * Major codes like `z:65` and `a:97` denote two digit `Minor` range, codes `Y:66`
- * and `B:98` denote 3 digit `Minor`. Each subsequent `Major` denotes increasingly
+ * Major codes like `Z:65` and `a:97` denote two digit `Minor` range, codes `Y:66`
+ * and `b:98` denote 3 digit `Minor`. Each subsequent `Major` denotes increasingly
  * large range for `Minor` position, making `A` and `z` a 27 digit ranges.
  *
  * While use of `Major` bytes between [90...122] is NOT RECOMMENDED we may still

--- a/src/position/major.js
+++ b/src/position/major.js
@@ -1,6 +1,7 @@
 import * as Digit from './digit.js'
+import * as Digits from './digits.js'
 import * as Minor from './minor.js'
-import { base58 as base } from './digits.js'
+import { base52 as base } from './digits.js'
 import * as Base from './base.js'
 
 import { EQUAL, CONSECUTIVE } from './digits.js'
@@ -17,10 +18,6 @@ export const max = new Uint8Array([MAX, ...new Uint8Array(MAX).fill(Minor.MAX)])
 export const zero = () => innerPositive
 
 export { EQUAL, CONSECUTIVE }
-
-/**
- * @typedef {Digit.Uint8} Uint8
- */
 
 /**
  * Major byte describes the size range of the minor positions. It highly
@@ -41,7 +38,7 @@ export { EQUAL, CONSECUTIVE }
  * that insertions outside of recommended range would not be able to take
  * advantage of producing small positions.
  *
- * @typedef {Digit.Uint8 & {Major?:{}}} Major
+ * @typedef {Digits.B52} Major
  */
 
 /**
@@ -80,7 +77,7 @@ export const decrement = (major) => {
   if (digit < 0) {
     return null
   } else {
-    return digit
+    return /** @type {Major} */ (digit)
   }
 }
 
@@ -103,7 +100,7 @@ export const increment = (major) => {
   if (digit < 0) {
     return null
   } else {
-    return digit
+    return /** @type {Major} */ (digit)
   }
 }
 
@@ -117,7 +114,7 @@ export const intermediate = (from, to) =>
   Digit.intermediate(from, to, base.ranges)
 
 /**
- * @param {Uint8Array} position
- * @returns {Digit.Uint8}
+ * @param {import('./position.js').Position} position
+ * @returns {Major}
  */
 export const from = (position) => position[0]

--- a/src/position/major.js
+++ b/src/position/major.js
@@ -2,6 +2,8 @@ import * as Digit from './digit.js'
 import * as Minor from './minor.js'
 import { base58 as base } from './digits.js'
 
+import { EQUAL, CONSECUTIVE } from './digits.js'
+
 const [[outerNegative, innerNegative], [innerPositive, outerPositive]] =
   base.ranges
 
@@ -13,9 +15,10 @@ export const min = new Uint8Array([MIN, ...new Uint8Array(MIN).fill(Minor.MIN)])
 export const max = new Uint8Array([MAX, ...new Uint8Array(MAX).fill(Minor.MAX)])
 export const zero = () => innerPositive
 
+export { EQUAL, CONSECUTIVE }
+
 /**
  * @typedef {Digit.Uint8} Uint8
- * @typedef {Digit.OutOfBound} OutOfBound
  */
 
 /**
@@ -107,7 +110,7 @@ export const increment = (major) => {
  *
  * @param {Major} from
  * @param {Major} to
- * @returns {Major|Digit.OutOfBound}
+ * @returns {Major|EQUAL|CONSECUTIVE}
  */
 export const intermediate = (from, to) =>
   Digit.intermediate(from, to, base.ranges)

--- a/src/position/major.js
+++ b/src/position/major.js
@@ -1,0 +1,119 @@
+import * as Digit from './digit.js'
+import * as Minor from './minor.js'
+import { base58 as base } from './digits.js'
+
+const [[outerNegative, innerNegative], [innerPositive, outerPositive]] =
+  base.ranges
+
+export { base }
+export const MIN = base.min
+export const MAX = base.max
+
+export const min = new Uint8Array([MIN, ...new Uint8Array(MIN).fill(Minor.MIN)])
+export const max = new Uint8Array([MAX, ...new Uint8Array(MAX).fill(Minor.MAX)])
+export const zero = () => innerPositive
+
+/**
+ * @typedef {Digit.Uint8} Uint8
+ * @typedef {Digit.OutOfBound} OutOfBound
+ */
+
+/**
+ * Major byte describes the size range of the minor positions. It highly
+ * recommended to use only bytes in the  'A-Za-z' character code range meaning
+ *
+ * ```
+ * [65...90,  97..122]
+ * ```
+ *
+ * Major codes like `z:65` and `a:97` denote two digit `Minor` range, codes `Y:66`
+ * and `B:98` denote 3 digit `Minor`. Each subsequent `Major` denotes increasingly
+ * large range for `Minor` position, making `A` and `z` a 27 digit ranges.
+ *
+ * While use of `Major` bytes between [90...122] is NOT RECOMMENDED we may still
+ * encounter those in practice, therefor they demark `0` size `Minor` range
+ * implying that rest of the bytes will constitute `Patch` digits. Same applies
+ * to the ranges between [0...65] and [122...255]. In practice it would mean
+ * that insertions outside of recommended range would not be able to take
+ * advantage of producing small positions.
+ *
+ * @typedef {Digit.Uint8 & {Major?:{}}} Major
+ */
+
+/**
+ * Derives capacity of the minor component from the major component. It is
+ * designed such that minor components in the middle have smaller capacity
+ * and those on the edges have larger capacity. This way we can increase
+ * position size logarithmically when inserting items at the end or the start.
+ *
+ * @param {Major} major
+ */
+export const capacity = (major) => {
+  if (major >= innerPositive && major <= outerPositive) {
+    return major - innerPositive + 1
+  } else if (major >= outerNegative && major <= innerNegative) {
+    return innerNegative - major + 1
+  } else {
+    return 0
+  }
+}
+
+/**
+ * Decrement the `major` component. If the `major` component is already at the
+ * minimum decremented digit would be out of bounds in which case `null` is
+ * returned.
+ *
+ * Please note that passed `major` may be out of bounds (when bytes outside of
+ * the recommended range are used) in such case decrement will either move it
+ * to the nearest smaller value in supported range or return `null` if no such
+ * value exists.
+ *
+ * @param {Major} major
+ * @returns {Major|null}
+ */
+export const decrement = (major) => {
+  const digit = Digit.decrement(major, base.ranges)
+  if (digit < 0) {
+    return null
+  } else {
+    return digit
+  }
+}
+
+/**
+ * Increment the `major` component. If the `major` component is already at the
+ * maximum incremented digit would be out of bounds in which case `null` is
+ * returned.
+ *
+ * Please note that passed `major` may be out of bounds (when bytes outside of
+ * the recommended range are used) in such case increment will either move it
+ * to the nearest greater value in supported range or return `null` if no such
+ * value exists.
+ *
+ *
+ * @param {Major} major
+ * @returns {Major|null}
+ */
+export const increment = (major) => {
+  const digit = Digit.increment(major, base.ranges)
+  if (digit < 0) {
+    return null
+  } else {
+    return digit
+  }
+}
+
+/**
+ *
+ * @param {Major} from
+ * @param {Major} to
+ * @returns {Major|Digit.OutOfBound}
+ */
+export const intermediate = (from, to) =>
+  Digit.intermediate(from, to, base.ranges)
+
+/**
+ * @param {Uint8Array} position
+ * @returns {Digit.Uint8}
+ */
+export const from = (position) => position[0]

--- a/src/position/minor.js
+++ b/src/position/minor.js
@@ -1,12 +1,12 @@
 import * as Digits from './digits.js'
+import * as Base from './base.js'
 export { EQUAL, CONSECUTIVE } from './digits.js'
 import * as Major from './major.js'
 export const { base62: base } = Digits
 
-export const MIN = base.min
-
+export const MIN = Base.min(base)
+export const MAX = Base.max(base)
 export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
-export const MAX = base.max
 
 /**
  * @typedef {Uint8Array & {Minor?: {}}} Minor
@@ -33,7 +33,7 @@ export const from = (position) => {
   // values so that operations on digits will not make wrong assumptions about
   // the size.
   if (slice.length < length) {
-    const minor = new Uint8Array(length).fill(base.min)
+    const minor = new Uint8Array(length).fill(MIN)
     minor.set(slice)
     return minor
   }
@@ -52,13 +52,13 @@ export const intermediate = (low, high) =>
 /**
  * @param {number} size
  */
-export const max = (size) => new Uint8Array(size).fill(base.max)
+export const max = (size) => new Uint8Array(size).fill(MAX)
 
 /**
  *
  * @param {number} size
  */
-export const min = (size) => new Uint8Array(size).fill(base.min)
+export const min = (size) => new Uint8Array(size).fill(MIN)
 /**
  * @param {Minor} minor
  */

--- a/src/position/minor.js
+++ b/src/position/minor.js
@@ -9,12 +9,16 @@ export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
 export const MAX = base.max
 
 /**
- * @param {Uint8Array} minor
+ * @typedef {Uint8Array & {Minor?: {}}} Minor
+ */
+
+/**
+ * @param {Minor} minor
  */
 export const decrement = (minor) => Digits.decrement(minor, base.ranges)
 
 /**
- * @param {Uint8Array} minor
+ * @param {Minor} minor
  */
 export const increment = (minor) => Digits.increment(minor, base.ranges)
 
@@ -38,12 +42,12 @@ export const from = (position) => {
 
 /**
  *
- * @param {Uint8Array} lower
- * @param {Uint8Array} upper
+ * @param {Minor} low
+ * @param {Minor} high
  * @returns
  */
-export const intermediate = (lower, upper) =>
-  Digits.intermediate(lower, upper, base.ranges)
+export const intermediate = (low, high) =>
+  Digits.intermediate(low, high, base.ranges)
 
 /**
  * @param {number} size
@@ -51,6 +55,11 @@ export const intermediate = (lower, upper) =>
 export const max = (size) => new Uint8Array(size).fill(base.max)
 
 /**
- * @param {Uint8Array} minor
+ *
+ * @param {number} size
+ */
+export const min = (size) => new Uint8Array(size).fill(base.min)
+/**
+ * @param {Minor} minor
  */
 export const trim = (minor) => Digits.trim(minor, base.ranges)

--- a/src/position/minor.js
+++ b/src/position/minor.js
@@ -1,0 +1,56 @@
+import * as Digits from './digits.js'
+export { EQUAL, CONSECUTIVE } from './digits.js'
+import * as Major from './major.js'
+export const { base62: base } = Digits
+
+export const MIN = base.min
+
+export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
+export const MAX = base.max
+
+/**
+ * @param {Uint8Array} minor
+ */
+export const decrement = (minor) => Digits.decrement(minor, base.ranges)
+
+/**
+ * @param {Uint8Array} minor
+ */
+export const increment = (minor) => Digits.increment(minor, base.ranges)
+
+/**
+ * @param {Uint8Array} position
+ */
+export const from = (position) => {
+  const length = Major.capacity(Major.from(position))
+  const slice = position.subarray(1, 1 + length)
+  // Position trim trailing mins of the minor component when there is no patch
+  // component. If that is the case here we pad the minor component with min
+  // values so that operations on digits will not make wrong assumptions about
+  // the size.
+  if (slice.length < length) {
+    const minor = new Uint8Array(length).fill(base.min)
+    minor.set(slice)
+    return minor
+  }
+  return slice
+}
+
+/**
+ *
+ * @param {Uint8Array} lower
+ * @param {Uint8Array} upper
+ * @returns
+ */
+export const intermediate = (lower, upper) =>
+  Digits.intermediate(lower, upper, base.ranges)
+
+/**
+ * @param {number} size
+ */
+export const max = (size) => new Uint8Array(size).fill(base.max)
+
+/**
+ * @param {Uint8Array} minor
+ */
+export const trim = (minor) => Digits.trim(minor, base.ranges)

--- a/src/position/minor.js
+++ b/src/position/minor.js
@@ -6,7 +6,7 @@ export const { base62: base } = Digits
 
 export const MIN = Base.min(base)
 export const MAX = Base.max(base)
-export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
+export const MEDIAN = Base.median(base)
 
 /**
  * @typedef {Uint8Array & {Minor?: {}}} Minor

--- a/src/position/patch.js
+++ b/src/position/patch.js
@@ -89,10 +89,10 @@ export const intermediate = (low, high, bias) => {
 
 /**
  * @param {Patch} digits
+ * @param {Bias} bias
  */
-export const next = (digits) =>
-  // We know it will never be equal because we pass the max value.
-  /** @type {Patch} */ (intermediate(digits, max(), new Uint8Array([])))
+export const next = (digits, bias) =>
+  intermediate(digits, max(), bias) || append(digits, bias)
 
 /**
  * @param {Patch} digits
@@ -125,18 +125,42 @@ const decrease = (digits) => {
 
 /**
  *
- * @param {Patch} digits
+ * @param {Patch} patch
+ * @param {Bias} bias
  * @returns {Patch}
  */
-export const increment = (digits) =>
-  Digits.increment(digits, base.ranges) ?? append(digits, median)
+export const increment = (patch, bias) => {
+  const digits = Digits.increment(patch, base.ranges)
+  const [head] = bias
+  if (digits == null) {
+    return append(patch, median)
+  } else if (head == null) {
+    return digits
+  } else if (head >= digits[0]) {
+    return bias
+  } else {
+    return append(digits, bias)
+  }
+}
 
 /**
- * @param {Patch} digits
+ * @param {Patch} patch
+ * @param {Bias} bias
  * @returns {Patch|null}
  */
-export const decrement = (digits) =>
-  Digits.decrement(digits, base.ranges) ?? decrease(digits)
+export const decrement = (patch, bias) => {
+  const digits = Digits.decrement(patch, base.ranges)
+  const [head] = bias
+  if (digits == null) {
+    return decrease(patch)
+  } else if (head == null) {
+    return digits
+  } else if (head <= digits[0]) {
+    return bias
+  } else {
+    return append(digits, bias)
+  }
+}
 
 /**
  * @param {Patch} digits

--- a/src/position/patch.js
+++ b/src/position/patch.js
@@ -6,16 +6,25 @@ export const { base62: base } = Digits
 export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
 
 /**
+ * @typedef {Uint8Array & {Patch?: {}}} Patch
+ */
+
+/**
  * @param {Uint8Array} position
+ * @returns {Patch}
  */
 export const from = (position) =>
   position.subarray(Major.capacity(Major.from(position)) + 1)
 
 /**
- *
- * @param {Digits.Uint8} size
+ * @returns {Patch}
  */
-export const max = (size) => new Uint8Array(size).fill(base.max)
+export const max = () => new Uint8Array([base.max + 1])
+
+/**
+ * @returns {Patch}
+ */
+export const min = () => new Uint8Array([base.min - 1])
 
 /**
  * Returns an intermediate patch value that would sort between `lower` and
@@ -23,22 +32,31 @@ export const max = (size) => new Uint8Array(size).fill(base.max)
  * which is what will happen if `lower` and `upper` are consecutive. If lower
  * and upper are the same function will return `null`.
  *
- * @param {Uint8Array} lower
- * @param {Uint8Array} upper
+ * @param {Patch} low
+ * @param {Patch} high
+ * @returns {Patch|null}
  */
-export const intermediate = (lower, upper) => {
-  const digits = Digits.intermediate(lower, upper, base.ranges)
+export const intermediate = (low, high) => {
+  const digits = Digits.intermediate(low, high, base.ranges)
   // If lower and upper are consecutive, we can derive average by adding
   // another digit to the `lower` position. This would make it
   if (digits === Digits.CONSECUTIVE) {
-    return increase(lower)
+    return increase(low)
   } else {
     return digits == Digits.EQUAL ? null : digits
   }
 }
 
 /**
- * @param {Uint8Array} digits
+ * @param {Patch} digits
+ */
+export const next = (digits) =>
+  // We know it will never be equal because we pass the max value.
+  /** @type {Patch} */ (intermediate(digits, max()))
+
+/**
+ * @param {Patch} digits
+ * @returns {Patch}
  */
 const increase = (digits) => {
   const patch = new Uint8Array(digits.length + 1)
@@ -48,7 +66,8 @@ const increase = (digits) => {
 }
 
 /**
- * @param {Uint8Array} digits
+ * @param {Patch} digits
+ * @returns {Patch|null}
  */
 const decrease = (digits) => {
   let offset = digits.length - 1
@@ -56,29 +75,30 @@ const decrease = (digits) => {
     offset--
   }
 
-  if (offset === 0) {
+  if (offset <= 0) {
     return null
   } else {
-    return digits.subarray(0, offset)
+    return digits.subarray(0, offset + 1)
   }
 }
 
 /**
  *
- * @param {Uint8Array} digits
- * @returns
+ * @param {Patch} digits
+ * @returns {Patch}
  */
 export const increment = (digits) =>
   Digits.increment(digits, base.ranges) ?? increase(digits)
 
 /**
- * @param {Uint8Array} digits
- * @returns
+ * @param {Patch} digits
+ * @returns {Patch|null}
  */
 export const decrement = (digits) =>
   Digits.decrement(digits, base.ranges) ?? decrease(digits)
 
 /**
- * @param {Uint8Array} digits
+ * @param {Patch} digits
+ * @returns {Patch}
  */
 export const trim = (digits) => Digits.trim(digits, base.ranges)

--- a/src/position/patch.js
+++ b/src/position/patch.js
@@ -1,0 +1,84 @@
+import * as Digits from './digits.js'
+import * as Major from './major.js'
+export const { CONSECUTIVE, EQUAL } = Digits
+export const { base62: base } = Digits
+
+export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
+
+/**
+ * @param {Uint8Array} position
+ */
+export const from = (position) =>
+  position.subarray(Major.capacity(Major.from(position)) + 1)
+
+/**
+ *
+ * @param {Digits.Uint8} size
+ */
+export const max = (size) => new Uint8Array(size).fill(base.max)
+
+/**
+ * Returns an intermediate patch value that would sort between `lower` and
+ * `upper`. Since patches are treated as fractions they can grow in size
+ * which is what will happen if `lower` and `upper` are consecutive. If lower
+ * and upper are the same function will return `null`.
+ *
+ * @param {Uint8Array} lower
+ * @param {Uint8Array} upper
+ */
+export const intermediate = (lower, upper) => {
+  const digits = Digits.intermediate(lower, upper, base.ranges)
+  // If lower and upper are consecutive, we can derive average by adding
+  // another digit to the `lower` position. This would make it
+  if (digits === Digits.CONSECUTIVE) {
+    return increase(lower)
+  } else {
+    return digits == Digits.EQUAL ? null : digits
+  }
+}
+
+/**
+ * @param {Uint8Array} digits
+ */
+const increase = (digits) => {
+  const patch = new Uint8Array(digits.length + 1)
+  patch.set(digits)
+  patch[digits.length] = MEDIAN
+  return patch
+}
+
+/**
+ * @param {Uint8Array} digits
+ */
+const decrease = (digits) => {
+  let offset = digits.length - 1
+  while (offset > 0 && digits[offset] === base.min) {
+    offset--
+  }
+
+  if (offset === 0) {
+    return null
+  } else {
+    return digits.subarray(0, offset)
+  }
+}
+
+/**
+ *
+ * @param {Uint8Array} digits
+ * @returns
+ */
+export const increment = (digits) =>
+  Digits.increment(digits, base.ranges) ?? increase(digits)
+
+/**
+ * @param {Uint8Array} digits
+ * @returns
+ */
+export const decrement = (digits) =>
+  Digits.decrement(digits, base.ranges) ?? decrease(digits)
+
+/**
+ * @param {Uint8Array} digits
+ */
+export const trim = (digits) => Digits.trim(digits, base.ranges)

--- a/src/position/patch.js
+++ b/src/position/patch.js
@@ -118,7 +118,9 @@ const decrease = (digits) => {
 
   if (offset <= 0) {
     return null
-  } else {
+  }
+  ///* c8 ignore next 3 */
+  else {
     return digits.subarray(0, offset + 1)
   }
 }
@@ -149,10 +151,12 @@ export const increment = (patch, bias) => {
  * @returns {Patch|null}
  */
 export const decrement = (patch, bias) => {
-  const digits = Digits.decrement(patch, base.ranges)
+  const digits = Digits.decrement(patch, base.ranges) || decrease(patch)
   const [head] = bias
+  // If we can not create decremented nor shorten patch we give up.
+  // we
   if (digits == null) {
-    return decrease(patch)
+    return null
   } else if (head == null) {
     return digits
   } else if (head <= digits[0]) {

--- a/src/position/patch.js
+++ b/src/position/patch.js
@@ -1,7 +1,11 @@
 import * as Digits from './digits.js'
 import * as Major from './major.js'
+import * as Base from './base.js'
 export const { CONSECUTIVE, EQUAL } = Digits
 export const { base62: base } = Digits
+
+export const MIN = Base.min(base)
+export const MAX = Base.max(base)
 
 export const MEDIAN = base.codes[(base.codes.length / 2) | 0]
 
@@ -19,12 +23,12 @@ export const from = (position) =>
 /**
  * @returns {Patch}
  */
-export const max = () => new Uint8Array([base.max + 1])
+export const max = () => new Uint8Array([MAX + 1])
 
 /**
  * @returns {Patch}
  */
-export const min = () => new Uint8Array([base.min - 1])
+export const min = () => new Uint8Array([MIN - 1])
 
 /**
  * Returns an intermediate patch value that would sort between `lower` and
@@ -71,7 +75,7 @@ const increase = (digits) => {
  */
 const decrease = (digits) => {
   let offset = digits.length - 1
-  while (offset > 0 && digits[offset] === base.min) {
+  while (offset > 0 && digits[offset] === MIN) {
     offset--
   }
 

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -1,0 +1,200 @@
+import * as Major from './major.js'
+import * as Minor from './minor.js'
+import * as Patch from './patch.js'
+
+/**
+ *
+ * @param {Uint8Array} position
+ * @param {Uint8Array} bias
+ * @returns {Uint8Array}
+ */
+export const withBias = (position, bias) => position
+
+const BLANK = new Uint8Array()
+
+/**
+ * @param {Major.Uint8} major
+ * @param {Uint8Array} minor
+ * @param {Uint8Array} patch
+ */
+const create = (major, minor = BLANK, patch = BLANK) => {
+  // Remove trailing min values from patch component.
+  patch = Patch.trim(patch)
+  // If patch is empty also trim trailing min values from minor component.
+  minor = patch.length === 0 ? Minor.trim(minor) : minor
+
+  const position = new Uint8Array(1 + minor.length + patch.length)
+  position[0] = major
+  position.set(minor, 1)
+  position.set(patch, 1 + minor.length)
+
+  return position
+}
+
+/**
+ * @param {Uint8Array} bias
+ * @param {Uint8Array} before
+ */
+export const insertBefore = (bias, before) => {
+  const beforeMajor = Major.from(before)
+  const beforeMinor = Minor.from(before)
+  // We attempt to decrement minor component first.
+  const minor = Minor.decrement(beforeMinor)
+  // If we have not run out of space for minor component we simply
+  // need to create position with the same major component and decremented
+  // minor component.
+  if (minor) {
+    return withBias(create(beforeMajor, minor), bias)
+  }
+  // However minor component may be at min value.
+  else {
+    // In that case we attempt to decrement major component.
+    const major = Major.decrement(beforeMajor)
+    // If major is not at it's min value we can simply create a new position
+    // with it and leave out minor and patch components which implicitly will
+    // be at their min values.
+    if (major) {
+      const minor = Minor.max(Major.capacity(major))
+      return withBias(create(major, minor), bias)
+    }
+    // However we are at min major our only option left is to decrement patch
+    // component and create a new position with the same major and minor.
+    else {
+      // Attempt to decrement patch component.
+      const patch = Patch.decrement(Patch.from(before))
+      // If we managed to decrement patch component we can create a new position
+      // with the same major and minor components and decremented patch component.
+      if (patch) {
+        return withBias(create(beforeMajor, beforeMinor, patch), bias)
+      }
+      // However if  patch component is at min value there is simply no position
+      // in the supported range that would sort before `before` position, therefore
+      // we return the same `before` position.
+      else {
+        return before
+      }
+    }
+  }
+}
+
+/**
+ * @param {Uint8Array} bias
+ * @param {Uint8Array} after
+ */
+export const insertAfter = (bias, after) => {
+  const afterMajor = Major.from(after)
+  const afterMinor = Minor.from(after)
+  // We first attempt to increment minor component.
+  const minor = Minor.increment(afterMinor)
+  // If we have not run out of space for minor component we simply
+  // need to create position with the same major component and incremented
+  // minor component.
+  if (minor) {
+    return withBias(create(afterMajor, minor), bias)
+  }
+  // However minor component may be at max value.
+  else {
+    // In that case we attempt to increment major component.
+    const major = Major.increment(afterMajor)
+    // If major is not at it's max value we can simply create a new position
+    // with it and leave out minor and patch components which implicitly will
+    // be at their minimum values.
+    if (major) {
+      return withBias(create(major), bias)
+    }
+    // However we are at max major our only option left is to increment patch
+    // component and create a new position with the same major and minor.
+    else {
+      // Note that patch can always increment because it simply resizes to
+      // accommodate larger values.
+      const patch = Patch.increment(Patch.from(after))
+      return withBias(create(afterMajor, afterMinor, patch), bias)
+    }
+  }
+}
+
+/**
+ * @param {Uint8Array} bias
+ * @param {Uint8Array} after
+ * @param {Uint8Array} before
+ */
+export const insertBetween = (bias, after, before) => {
+  const afterMajor = Major.from(after)
+  const beforeMajor = Major.from(before)
+  const major = Major.intermediate(afterMajor, beforeMajor)
+  // If we found an intermediate major component we're done as that is only
+  // component we'll need.
+  if (major >= 0) {
+    return withBias(create(major), bias)
+  }
+  // If we could not find an intermediate major component then two are
+  // either consecutive or equal.
+  else {
+    const afterMinor = Minor.from(after)
+    // If majors are equal we need to find intermediate minor component between
+    // the two. If they are consecutive we can simply find an intermediate minor
+    // between the `after` and a maximum minor component.
+    const beforeMinor =
+      major === beforeMajor
+        ? Minor.from(before)
+        : Minor.max(Major.capacity(beforeMajor))
+    const minor = Minor.intermediate(afterMinor, beforeMinor)
+    switch (minor) {
+      // If minor components are equal, or consecutive we won't be able to
+      // calculate the average of minor components. In such case we will pick
+      // the minor component from `after`. And calculate the average between
+      // patches.
+      case Minor.EQUAL:
+      case Minor.CONSECUTIVE: {
+        const afterPatch = Patch.from(after)
+        const beforePatch =
+          // We use greater patch size in case low is all max values that
+          // will ensure that minor will not return `null`.
+          minor === Minor.CONSECUTIVE
+            ? Patch.max(afterPatch.length + 1)
+            : Patch.from(before)
+        const patch = Patch.intermediate(afterPatch, beforePatch)
+        // If `after` and `before` are the same there will be no intermediate
+        // patch value so we'll have no other choice than use the same `after`
+        // position.
+        if (patch == null) {
+          return after
+        }
+        // If `after` and `before` are consecutive we will find an intermediate
+        // patch that will sort between them. In such case we construct position
+        // with the same major and minor components and new consecutive patch
+        // component.
+        else {
+          return create(afterMajor, afterMinor, patch)
+        }
+      }
+      // If minor components were not consecutive we'll find an intermediate
+      // minor component and will construct a new position with the same major
+      // and consecutive minor component. Patch component will be empty since
+      // new position will sort between `after` and `before` and we prefer
+      // compact positions over precisely middle ones.
+      default: {
+        return withBias(create(afterMajor, minor), bias)
+      }
+    }
+  }
+}
+
+/**
+ * @param {Uint8Array} bias
+ * @param {object} at
+ * @param {Uint8Array} [at.after]
+ * @param {Uint8Array} [at.before]
+ */
+export const insert = (bias, { after, before }) => {
+  if (before != null && after != null) {
+    return insertBetween(bias, after, before)
+  } else if (before != null) {
+    return insertBefore(bias, before)
+  } else if (after != null) {
+    return insertAfter(bias, after)
+  } else {
+    // We do not need to specify minor part because 0s are implicit.
+    return create(Major.zero())
+  }
+}

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -44,7 +44,6 @@ const create = (major, minor = BLANK, patch = BLANK) => {
 export const before = (bias, position) => {
   const beforeMajor = Major.from(position)
   const beforeMinor = Minor.from(position)
-  const patch = Patch.decrement(Patch.from(position))
 
   // We attempt to decrement minor component first.
   const minor = Minor.decrement(beforeMinor)

--- a/test/digits.spec.js
+++ b/test/digits.spec.js
@@ -1,0 +1,55 @@
+import * as Digits from '../src/position/digits.js'
+import * as UTF from '../src/utf8.js'
+
+export const increment = /** @type {const} */ ([
+  ['a', 'b'],
+  ['az', 'b'],
+  ['0', '1'],
+  ['10', '11'],
+  ['9', 'A'],
+  ['z', null],
+  ['bcd111z', 'bcd112'],
+])
+
+export const decrement = /** @type {const} */ ([
+  ['a', 'Z'],
+  ['az', 'ay'],
+  ['0', null],
+  ['10', '0z'],
+  ['101', '1'],
+  ['120', '11z'],
+  ['9', '8'],
+  ['z', 'y'],
+])
+
+/**
+ * @type {import('entail').Suite}
+ */
+export const testDigits = {
+  increment: Object.fromEntries(
+    increment.map(([input, expect]) => [
+      `Digits.increment(${input}) => ${expect}`,
+      (assert) => {
+        const actual = Digits.increment(UTF.toUTF8(input), Digits.base62.ranges)
+        assert.deepEqual(
+          actual,
+          expect ? UTF.toUTF8(expect) : expect,
+          `${actual ? UTF.fromUTF8(actual) : null} == ${expect}`
+        )
+      },
+    ])
+  ),
+  decrement: Object.fromEntries(
+    decrement.map(([input, expect]) => [
+      `Digits.decrement(${input}) => ${expect}`,
+      (assert) => {
+        const actual = Digits.decrement(UTF.toUTF8(input), Digits.base62.ranges)
+        assert.deepEqual(
+          actual,
+          expect ? UTF.toUTF8(expect) : expect,
+          `${actual ? UTF.fromUTF8(actual) : null} == ${expect}`
+        )
+      },
+    ])
+  ),
+}

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -1,32 +1,5 @@
 import * as Position from '../src/position/lib.js'
 
-/**
- * @type {[string, string][]}
- */
-const BASE_95_increments = [
-  ['a0', 'a1'],
-  ['a1', 'a2'],
-  ['a~', 'b'],
-  ['a0z', 'a0{'],
-  ['a0{', 'a0|'],
-  ['a0|', 'a0}'],
-  ['a0}', 'a0~'],
-  ['a0~', 'a1'],
-  ['b0z', 'b0{'],
-  ['b0~', 'b1'],
-  ['b1~', 'b2'],
-  ['b~~', 'c'],
-  ['Zy', 'Zz'],
-  ['Z~', '['],
-  ['`~', 'a'],
-  ['Yzy', 'Yzz'],
-  // ['Yzz', 'Z0'],
-  // ['Xyzz', 'Xz00'],
-  ['Xz00', 'Xz01'],
-  // ['Xzzz', 'Y00'],
-  // ['dABzz', 'dAC00'],
-]
-
 const after = [
   ['a', 'a1'], // trailing zeros are ignore
   ['_1', 'a'], // invalid range characters are skipped
@@ -89,6 +62,37 @@ const before = [
   ['Zz2', 'Zy'],
 ]
 
+export const insert = /** @type {const} */ ([
+  [, , 'a'],
+  [, 'a', 'Zz'],
+  ['a0', , 'a1'],
+  ['a0', 'a1', 'a0V'],
+  ['a0V', 'a1', 'a0i'],
+  ['Zz', 'a0', 'ZzV'],
+  ['Zz', 'a1', 'a'],
+  [, 'Y00', 'Xzzz'],
+  ['bzz', , 'c'],
+  ['a0', 'a0V', 'a0C'],
+  ['a0', 'a0G', 'a0A'],
+  ['b125', 'b129', 'b127'],
+  ['a0', 'a1V', 'a1'],
+  ['a0', 'a10', 'a0V'],
+  ['a0', 'a11', 'a1'],
+  ['Zz', 'a01', 'a'],
+  [, 'a0V', 'Zz'], // skip a because a0V could not have happened without `a`.
+  // [, 'a0V', 'a'],
+  [, 'b999', 'b98'], // b999 would not have happened without b99
+  // [, 'b999', 'b99'],
+  [, 'A00000000000000000000000000', 'A'],
+  [, 'A000000000000000000000000001', 'A'],
+  ['zzzzzzzzzzzzzzzzzzzzzzzzzzy', , 'zzzzzzzzzzzzzzzzzzzzzzzzzzz'],
+  ['zzzzzzzzzzzzzzzzzzzzzzzzzzz', , 'zzzzzzzzzzzzzzzzzzzzzzzzzzzV'],
+  ['a00', , 'a1'],
+  ['a00', 'a1', 'a0V'],
+  ['0', '1', '0V'],
+  // ['a1', 'a0', 'a1V'], // should error
+])
+
 const empty = new Uint8Array()
 
 /**
@@ -112,7 +116,7 @@ export const testDigits = {
         const actual = Position.insert(empty, { after: position })
 
         assert.ok(position <= actual, `${position} <= ${actual}`)
-        assert.equal(expect, actual)
+        assert.equal(actual, expect)
       },
     ])
   ),
@@ -124,7 +128,24 @@ export const testDigits = {
         const actual = Position.insert(empty, { before: position })
 
         assert.ok(position >= actual, `${position} >= ${actual}`)
-        assert.equal(expect, actual)
+        assert.equal(actual, expect)
+      },
+    ])
+  ),
+
+  ...Object.fromEntries(
+    insert.map(([after, before, expect]) => [
+      `Position.insert(null, { before: ${before}, after: ${after} })) => ${expect}`,
+      (assert) => {
+        const actual = Position.insert(empty, { after, before })
+
+        assert.equal(actual, expect)
+        if (before) {
+          assert.ok(actual <= before, `${actual} <= ${before}`)
+        }
+        if (after) {
+          assert.ok(actual >= after, `${actual} >= ${after}`)
+        }
       },
     ])
   ),

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -1,0 +1,131 @@
+import * as Position from '../src/position/lib.js'
+
+/**
+ * @type {[string, string][]}
+ */
+const BASE_95_increments = [
+  ['a0', 'a1'],
+  ['a1', 'a2'],
+  ['a~', 'b'],
+  ['a0z', 'a0{'],
+  ['a0{', 'a0|'],
+  ['a0|', 'a0}'],
+  ['a0}', 'a0~'],
+  ['a0~', 'a1'],
+  ['b0z', 'b0{'],
+  ['b0~', 'b1'],
+  ['b1~', 'b2'],
+  ['b~~', 'c'],
+  ['Zy', 'Zz'],
+  ['Z~', '['],
+  ['`~', 'a'],
+  ['Yzy', 'Yzz'],
+  // ['Yzz', 'Z0'],
+  // ['Xyzz', 'Xz00'],
+  ['Xz00', 'Xz01'],
+  // ['Xzzz', 'Y00'],
+  // ['dABzz', 'dAC00'],
+]
+
+const after = [
+  ['a', 'a1'], // trailing zeros are ignore
+  ['_1', 'a'], // invalid range characters are skipped
+  ['0', 'A'], // incrementing a major digit
+  ['023242', 'A'], // incrementing a major digit
+  ['a00', 'a1'], // patch component is dropped when incrementing
+  ['a0', 'a1'], // trailing do not affect increment
+  ['a1', 'a2'], // incrementing a minor digit
+  ['az', 'b'], // incrementing a major digit
+  ['b', 'b01'], // incrementing a minor digit
+  ['b0z', 'b1'], // incrementing a major digit and trim
+  ['b1', 'b11'], // incrementing a minor digit
+  ['b1z', 'b2'], // incrementing a major digit
+  ['bzz', 'c'], // incrementing a major digit
+  ['c', 'c001'], // incrementing a minor digit
+  ['Zy', 'Zz'], // incrementing a minor digit
+  ['Zz', 'a'],
+  ['Yzy', 'Yzz'],
+  ['Yzz', 'Z'],
+  ['Xyzz', 'Xz'],
+  ['Xz00', 'Xz01'],
+  ['Xz', 'Xz01'],
+  ['Xz0', 'Xz01'],
+  ['Xzzz', 'Y'],
+  ['Xzzz01', 'Y'],
+  ['dABzz', 'dAC'],
+  ['z', 'z00000000000000000000000001'], // incrementing a minor digit
+  ['zzzzzzzzzzzzzzzzzzzzzzzzzzz', 'zzzzzzzzzzzzzzzzzzzzzzzzzzzV'], // incrementing a patch
+  ['~', '~V'], // incrementing a on invalid range
+  ['~V', '~W'], // incrementing a on invalid range
+  ['~W', '~X'], // incrementing a on invalid range
+  ['~X', '~Y'], // incrementing a on invalid range
+  ['~Z', '~a'], // incrementing a on invalid range
+  ['~z', '~zV'], // incrementing a on invalid range
+  ['~zV', '~zW'], // incrementing a on invalid range
+]
+
+const before = [
+  ['a1', 'a'],
+  ['a2', 'a1'],
+  ['b00', 'az'],
+  ['b10', 'b0z'],
+  ['b20', 'b1z'],
+  ['c000', 'bzz'],
+  ['Zz', 'Zy'],
+  ['a0', 'Zz'],
+  ['Yzz', 'Yzy'],
+  ['Z0', 'Yzz'],
+  ['Xz00', 'Xyzz'],
+  ['Xz01', 'Xz'],
+  ['Y00', 'Xzzz'],
+  ['dAC00', 'dABzz'],
+  ['A00000000000000000000000000', 'A'],
+  ['A00000000000000000000000001', 'A'],
+  ['A00000000000000000000000002', 'A00000000000000000000000001'],
+  ['A00000000000000000000000011', 'A0000000000000000000000001'],
+  ['~', 'zzzzzzzzzzzzzzzzzzzzzzzzzzz'],
+  ['~1089', 'zzzzzzzzzzzzzzzzzzzzzzzzzzz'],
+  ['_a', 'Zz'],
+  ['Zz2', 'Zy'],
+]
+
+const empty = new Uint8Array()
+
+/**
+ * @type {import('entail').Suite}
+ */
+export const testDigits = {
+  // ...Object.fromEntries(
+  //   BASE_95_increments.map(([digits, consequent]) => [
+  //     `base95.increment(${digits}) => ${consequent}`,
+  //     (assert) => {
+  //       const actual = Digits.increment(Digits.fromString(digits))
+  //       const expect = Digits.fromString(consequent)
+  //       assert.equal(actual.toString(), expect.toString())
+  //     },
+  //   ])
+  // ),
+  ...Object.fromEntries(
+    after.map(([position, expect]) => [
+      `Position.insert(null, { after: "${position}" })) => ${expect}`,
+      (assert) => {
+        const actual = Position.insert(empty, { after: position })
+
+        assert.ok(position <= actual, `${position} <= ${actual}`)
+        assert.equal(expect, actual)
+      },
+    ])
+  ),
+
+  ...Object.fromEntries(
+    before.map(([position, expect]) => [
+      `Position.insert(null, { before: "${position}" })) => ${expect}`,
+      (assert) => {
+        const actual = Position.insert(empty, { before: position })
+
+        assert.ok(position >= actual, `${position} >= ${actual}`)
+        assert.equal(expect, actual)
+      },
+    ])
+  ),
+}

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -97,6 +97,12 @@ export const insert = /** @type {const} */ ([
   ['Y', '_', 'Z'],
   ['y', '{', 'z'],
   ['a01', 'a013', 'a012'],
+  ['A', 'C', 'B'],
+  ['A0', 'A2', 'A1'],
+  ['a1', 'b1', 'a2'],
+  ['a1a', 'a1c', 'a1b'],
+  ['a1a', 'a1a', 'a1a'], // no positions in between
+  ['a1a', 'a1b', 'a1aV'],
   // ['a1', 'a0', 'a1V'], // should error
 ])
 
@@ -212,5 +218,90 @@ export const testPositions = {
       }),
       'a01W'
     )
+  },
+
+  'insert after choose bias when between patches': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array([':'.charCodeAt(0)]), {
+        after: 'zzzzzzzzzzzzzzzzzzzzzzzzzzz1',
+      }),
+      'zzzzzzzzzzzzzzzzzzzzzzzzzzzW'
+    )
+  },
+
+  'insert after appends bias when bias is smaller': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array([':'.charCodeAt(0)]), {
+        after: 'zzzzzzzzzzzzzzzzzzzzzzzzzzzw',
+      }),
+      'zzzzzzzzzzzzzzzzzzzzzzzzzzzxW'
+    )
+  },
+
+  'insert before choose bias when between patches': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array([':'.charCodeAt(0)]), {
+        before: 'A00000000000000000000000000w',
+      }),
+      'A00000000000000000000000000W'
+    )
+  },
+
+  'insert appends bias when greater than decremented patch': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array(['#'.charCodeAt(0)]), {
+        before: 'A00000000000000000000000000w',
+      }),
+      'A00000000000000000000000000vz'
+    )
+
+    assert.ok('A00000000000000000000000000vz' < 'A00000000000000000000000000w')
+  },
+
+  'shortens patch when patch can not be decremented': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array(['#'.charCodeAt(0)]), {
+        before: 'A0000000000000000000000000000',
+      }),
+      'A'
+    )
+
+    assert.ok('A' < 'A0000000000000000000000000000')
+  },
+
+  'consecutive patches': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array(['#'.charCodeAt(0)]), {
+        after: 'a1A',
+        before: 'a1B',
+      }),
+      'a1Az'
+    )
+
+    assert.ok('a1A' < 'a1Az')
+    assert.ok('a1Az' < 'a1B')
+  },
+
+  'patches with bias': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array([':'.charCodeAt(0)]), {
+        after: 'a1A',
+        before: 'a1z',
+      }),
+      'a1W'
+    )
+  },
+
+  'patch next out of bound': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array([':'.charCodeAt(0)]), {
+        after: 'a1{',
+        before: 'a2',
+      }),
+      'a1{W'
+    )
+
+    assert.ok('a1{' < 'a1{W')
+    assert.ok('a1{W' < 'a2')
   },
 }

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -94,6 +94,9 @@ export const insert = /** @type {const} */ ([
   ['a00', , 'a1'],
   ['a00', 'a1', 'a0V'],
   ['0', '1', '0V'],
+  ['Y', '_', 'Z'],
+  ['y', '{', 'z'],
+  ['a01', 'a013', 'a012'],
   // ['a1', 'a0', 'a1V'], // should error
 ])
 
@@ -176,5 +179,38 @@ export const testPositions = {
     )
   },
 
-  'test digits': (assert) => {},
+  'test reverse order': (assert) => {
+    assert.equal(
+      Position.insert(new Uint8Array(), { after: '¾', before: 'y' }),
+      'z',
+      'can take in reverse order'
+    )
+  },
+  'test out of bound': (assert) => {
+    assert.deepEqual(
+      Position.Position.insert(new Uint8Array(), {
+        after: new Uint8Array(['¾'.charCodeAt(0)]),
+        before: new Uint8Array(['´'.charCodeAt(0)]),
+      }),
+      new Uint8Array(['¾'.charCodeAt(0), 'V'.charCodeAt(0)])
+    )
+  },
+
+  'test implicit 0s': (assert) => {
+    assert.deepEqual(
+      Position.insert(new Uint8Array([0]), {
+        before: 'a01',
+        after: 'a013',
+      }),
+      'a012'
+    )
+
+    assert.deepEqual(
+      Position.insert(new Uint8Array([0]), {
+        after: 'a02',
+        before: 'a013',
+      }),
+      'a01W'
+    )
+  },
 }

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -139,4 +139,36 @@ export const testDigits = {
       },
     ])
   ),
+
+  'test bias': (assert) => {
+    assert.equal(
+      Position.insert(new Uint8Array(), { after: 'a' }),
+      'a1',
+      'no fractional without a bias'
+    )
+
+    assert.equal(
+      Position.insert(new Uint8Array([5]), { after: 'a' }),
+      'a15',
+      'gets fraction with a bias'
+    )
+
+    assert.equal(
+      Position.insert(new Uint8Array([255, 200]), { after: 'a' }),
+      'a1h28',
+      'gets fraction with a bias'
+    )
+
+    assert.equal(
+      Position.insert(new Uint8Array([7, 255, 200]), { after: 'a' }),
+      'a12cnm',
+      'gets fraction with a bias'
+    )
+
+    assert.equal(
+      Position.insert(new Uint8Array([7, 255, 200, 4, 2]), { after: 'a' }),
+      'a1Bv4z5g',
+      'gets fraction with a bias'
+    )
+  },
 }

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -99,16 +99,6 @@ const empty = new Uint8Array()
  * @type {import('entail').Suite}
  */
 export const testDigits = {
-  // ...Object.fromEntries(
-  //   BASE_95_increments.map(([digits, consequent]) => [
-  //     `base95.increment(${digits}) => ${consequent}`,
-  //     (assert) => {
-  //       const actual = Digits.increment(Digits.fromString(digits))
-  //       const expect = Digits.fromString(consequent)
-  //       assert.equal(actual.toString(), expect.toString())
-  //     },
-  //   ])
-  // ),
   ...Object.fromEntries(
     after.map(([position, expect]) => [
       `Position.insert(null, { after: "${position}" })) => ${expect}`,

--- a/test/position.spec.js
+++ b/test/position.spec.js
@@ -26,6 +26,8 @@ const after = [
   ['Xzzz', 'Y'],
   ['Xzzz01', 'Y'],
   ['dABzz', 'dAC'],
+  ['c0zz', 'c1'],
+  ['bcd111z', 'bce'], // patch is trimmed
   ['z', 'z00000000000000000000000001'], // incrementing a minor digit
   ['zzzzzzzzzzzzzzzzzzzzzzzzzzz', 'zzzzzzzzzzzzzzzzzzzzzzzzzzzV'], // incrementing a patch
   ['~', '~V'], // incrementing a on invalid range
@@ -76,9 +78,11 @@ export const insert = /** @type {const} */ ([
   ['a0', 'a0G', 'a0A'],
   ['b125', 'b129', 'b127'],
   ['a0', 'a1V', 'a1'],
+  ['a0', 'a11', 'a1'],
   ['a0', 'a10', 'a0V'],
   ['a0', 'a11', 'a1'],
   ['Zz', 'a01', 'a'],
+  ['bcd111z', 'bcd113', 'bcd112'],
   [, 'a0V', 'Zz'], // skip a because a0V could not have happened without `a`.
   // [, 'a0V', 'a'],
   [, 'b999', 'b98'], // b999 would not have happened without b99
@@ -98,8 +102,8 @@ const empty = new Uint8Array()
 /**
  * @type {import('entail').Suite}
  */
-export const testDigits = {
-  ...Object.fromEntries(
+export const testPositions = {
+  after: Object.fromEntries(
     after.map(([position, expect]) => [
       `Position.insert(null, { after: "${position}" })) => ${expect}`,
       (assert) => {
@@ -111,7 +115,7 @@ export const testDigits = {
     ])
   ),
 
-  ...Object.fromEntries(
+  before: Object.fromEntries(
     before.map(([position, expect]) => [
       `Position.insert(null, { before: "${position}" })) => ${expect}`,
       (assert) => {
@@ -123,7 +127,7 @@ export const testDigits = {
     ])
   ),
 
-  ...Object.fromEntries(
+  insert: Object.fromEntries(
     insert.map(([after, before, expect]) => [
       `Position.insert(null, { before: ${before}, after: ${after} })) => ${expect}`,
       (assert) => {
@@ -171,4 +175,6 @@ export const testDigits = {
       'gets fraction with a bias'
     )
   },
+
+  'test digits': (assert) => {},
 }

--- a/test/position/base.spec.js
+++ b/test/position/base.spec.js
@@ -1,0 +1,24 @@
+import * as Base from '../../src/position/base.js'
+
+const BASE62 = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`
+
+/**
+ * @type {import('entail').Suite}
+ */
+export const testBase = {
+  testOversizedBase: (assert) => {
+    assert.throws(
+      () => Base.parse(`${BASE62}${BASE62}${BASE62}${BASE62}${BASE62}`),
+      /RangeError/
+    )
+  },
+
+  testBase62: (assert) => {
+    const base = Base.parse(BASE62)
+
+    assert.deepEqual(
+      Base.toBase(new Uint8Array([0]), base),
+      new Uint8Array([65])
+    )
+  },
+}

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -1,5 +1,5 @@
 import * as DB from '../src/lib.js'
-import { transact, query, Variable, match, not } from 'datalogia'
+import { transact, query, Var, match, not } from 'datalogia'
 
 import * as OS from 'node:os'
 import { Link, Task } from '../src/lib.js'
@@ -14,11 +14,11 @@ export const testQuery = {
     Task.spawn(function* () {
       const { db } = yield* open()
 
-      const list = Variable.link()
-      const title = Variable.string()
-      const name = Variable.string()
-      const done = Variable.boolean()
-      const todo = Variable.link()
+      const list = Var.link()
+      const title = Var.string()
+      const name = Var.string()
+      const done = Var.boolean()
+      const todo = Var.link()
 
       const matches = yield* query(db, {
         select: {
@@ -41,20 +41,22 @@ export const testQuery = {
         ],
       })
 
+      console.log(matches)
+
       assert.deepEqual(matches, [
         {
           name: 'Groceries',
           todo: [
             { title: 'Buy Bread', done: true },
-            { title: 'Buy Milk', done: false },
             { title: 'Buy Eggs', done: false },
+            { title: 'Buy Milk', done: false },
           ],
         },
         {
           name: 'Chores',
           todo: [
-            { title: 'Do Dishes', done: false },
             { title: 'Do Laundry', done: false },
+            { title: 'Do Dishes', done: false },
           ],
         },
       ])

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -41,8 +41,6 @@ export const testQuery = {
         ],
       })
 
-      console.log(matches)
-
       assert.deepEqual(matches, [
         {
           name: 'Groceries',


### PR DESCRIPTION
Implements positions [per article](https://observablehq.com/@gozala/deterministically-biased-fractional-indexing). There is whole bunch of code but the user facing API looks like:

```js
const position = Position.insert(identifier, {
  before: positionOfTheElementBefore,
  after: positionOfTheElementAfter
})
```

Both `before` and `after` are optional. Returned `position` can be used as an attribute in the assertions.


ℹ️ This is something we will include in the synopsys agent interface.


> 😅 After reflecting on the implementation, I'm realizing that it could have being simplified if it was designed differently. Specifically implementation entangles constraints that perhaps could have being avoided at the db layer. Specifically arithmetics is concerned with [robustness principal](https://en.wikipedia.org/wiki/Robustness_principle) and accepts arbitrary bytes as input positions, while doing it's best to produced well formed positions.
>
> I think better option would have being to just tag plain attributes and positions differently at db level. That way positions that do not parse could simply be treated as attributes as opposed to positions. It would imply that code could produce an error if you're passing attributes instead of positions, but that doesn't seem unreasonable, especially if type system along with query engine treated those as different.