### PR TITLE
feat: implement import support

### DIFF
--- a/src/datum.js
+++ b/src/datum.js
@@ -1,5 +1,4 @@
 import * as CBOR from '@ipld/dag-cbor'
-import { Link } from 'datalogia'
 import * as Reference from './datum/reference.js'
 
 /**

--- a/src/fact.js
+++ b/src/fact.js
@@ -1,7 +1,56 @@
-import { varint } from 'multiformats'
-
+import { refer } from './datum/reference.js'
+import * as Type from './replica/type.js'
+import { Constant } from 'datalogia'
+import * as Position from './position/lib.js'
 /**
- *
- * @param {import('datalogia').Fact} fact
+ * @param {Type.Fact} fact
  */
 export const toBytes = ([entity, attribute, value]) => {}
+
+/**
+ * @template {Type.Import} Source
+ * @param {Source} source
+ * @returns {Generator<Type.Fact, Type.Reference<Source>>}
+ */
+export const iterate = function* (source) {
+  const entity = refer(source)
+  for (const [key, value] of Object.entries(source)) {
+    switch (typeof value) {
+      case 'boolean':
+      case 'number':
+      case 'bigint':
+      case 'string':
+        yield [entity, key, value]
+        break
+      case 'object': {
+        if (Constant.is(value)) {
+          yield [entity, key, value]
+        } else if (Array.isArray(value)) {
+          let at
+          const array = refer(value)
+          for (const member of value) {
+            if (Constant.is(member)) {
+              const element = refer(member)
+              at = Position.insert(element['/'].subarray(-4), { after: at })
+              yield [array, at, member]
+            } else {
+              const element = yield* iterate(member)
+              at = Position.insert(element['/'].subarray(-4), { after: at })
+              yield [array, at, element]
+            }
+          }
+          yield [entity, key, array]
+        } else {
+          const object = yield* iterate(value)
+          yield [entity, key, object]
+        }
+        break
+      }
+      /* c8 ignore next 2 */
+      default:
+        throw new TypeError(`Unsupported value type: ${value}`)
+    }
+  }
+
+  return entity
+}

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -221,6 +221,6 @@ export const insert = (bias, at = {}) => {
     return after(bias, at.after)
   } else {
     // We do not need to specify minor part because 0s are implicit.
-    return create(Major.zero())
+    return create(Major.zero(), BLANK, bias)
   }
 }

--- a/src/replica/type.ts
+++ b/src/replica/type.ts
@@ -10,7 +10,10 @@ export type {
   InferBindings as Selection,
   Result,
   Variant,
+  Fact,
   Variable,
+  Attribute,
+  Instantiation as Import,
 } from 'datalogia'
 export type { BlockEncoder, BlockDecoder } from 'multiformats'
 export type { Task } from 'datalogia/task'
@@ -21,10 +24,13 @@ import type {
   Transaction,
   Query,
   Variable,
+  API,
 } from 'datalogia'
 import type { Invocation, Task } from 'datalogia/task'
 import type { Commit, Database as Store } from '../store/okra.js'
 import { Phantom } from 'multiformats'
+
+export type Constant = API.Constant
 
 export { Store, Commit }
 export type Revision = { id: string }

--- a/test/import.spec.js
+++ b/test/import.spec.js
@@ -1,0 +1,95 @@
+import * as Memory from 'synopsys/store/memory'
+import { Replica, Task, refer, $ } from 'synopsys'
+import { query } from 'datalogia'
+
+/**
+ * @type {import('entail').Suite}
+ */
+export const testImport = {
+  'test import object': (assert) =>
+    Task.spawn(function* () {
+      const store = yield* Memory.open()
+      const replica = yield* Replica.open({ local: { store } })
+
+      const source = {
+        name: 'synopsys',
+        keywords: ['datalog', 'db', 'datomic', 'graph'],
+        null: null,
+        dev: true,
+        score: 1024n,
+        dependencies: {
+          '@canvas-js/okra': '0.4.5',
+          '@canvas-js/okra-lmdb': '0.2.0',
+          '@canvas-js/okra-memory': '0.4.5',
+          '@ipld/dag-cbor': '^9.2.1',
+          '@ipld/dag-json': '10.2.2',
+          '@noble/hashes': '1.3.3',
+          '@types/node': '22.5.5',
+          datalogia: '^0.9.0',
+          multiformats: '^13.3.0',
+          'merkle-reference': '^0.0.3',
+        },
+        types: [{ './src/lib.js': './dist/lib.d.ts' }],
+      }
+
+      const entity = refer(source)
+      const commit = yield* Replica.transact(replica, [{ Import: source }])
+
+      const {
+        name,
+        dependencies,
+        keywords,
+        at,
+        keyword,
+        dependency,
+        version,
+        nil,
+      } = $
+
+      // TODO: Update test when grouping issue is fixed
+      // @see https://github.com/Gozala/datalogia/issues/50
+      const [groupKeywords] = yield* query(store, {
+        select: {
+          name,
+          keywords: [{ at, keyword }],
+          // dependencies: [{ name: dependency, version }],
+        },
+        where: [
+          { Case: [entity, 'name', name] },
+          { Case: [entity, 'null', nil] },
+          // { Case: [entity, 'dependencies', dependencies] },
+          { Case: [entity, 'keywords', keywords] },
+          { Case: [keywords, at, keyword] },
+          // { Case: [dependencies, dependency, version] },
+        ],
+      })
+
+      const foundKeywords = groupKeywords.keywords
+        .sort((left, right) => left.at.localeCompare(right.at))
+        .map(({ keyword }) => keyword)
+
+      assert.deepEqual(foundKeywords, source.keywords)
+
+      const [match] = yield* query(store, {
+        select: {
+          name,
+          null: $.null,
+          score: $.score,
+          dev: $.dev,
+        },
+        where: [
+          { Case: [entity, 'name', name] },
+          { Case: [entity, 'null', $.null] },
+          { Case: [entity, 'score', $.score] },
+          { Case: [entity, 'dev', $.dev] },
+        ],
+      })
+
+      assert.deepEqual(match, {
+        name: source.name,
+        null: source.null,
+        score: Number(source.score),
+        dev: source.dev,
+      })
+    }),
+}


### PR DESCRIPTION
Implementation adds support for

```js
Replica.transact(replica, {
   Import: json
})
```
Which will take care of decomposing things into facts and storing them.

⚠️ If what you import is very generic however you'll likely end up with conflicts, because entities identifiers are derived from structure itself.