### PR TITLE
feat: implement blob store

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,16 @@
       "types": "./dist/src/store/file.d.ts",
       "import": "./src/store/file.js",
       "default": "./src/store/file.js"
+    },
+    "./blob/memory": {
+      "types": "./dist/src/blob/memory.d.ts",
+      "import": "./src/blob/memory.js",
+      "default": "./src/blob/memory.js"
+    },
+    "./blob/disk": {
+      "types": "./dist/src/blob/disk.d.ts",
+      "import": "./src/blob/disk.js",
+      "default": "./src/blob/disk.js"
     }
   },
   "dependencies": {

--- a/src/blob.js
+++ b/src/blob.js
@@ -1,0 +1,20 @@
+import { Task } from 'datalogia'
+
+/**
+ * @typedef {{url: URL}} Open
+ */
+
+/**
+ * Connects to the  service by opening the underlying store.
+ *
+ * @param {Open} source
+ */
+export function* open(source) {
+  if (source.url.protocol === 'memory:') {
+    const Memory = yield* Task.wait(import('./blob/memory.js'))
+    return yield* Memory.open(source)
+  } else {
+    const Disk = yield* Task.wait(import('./blob/disk.js'))
+    return yield* Disk.open(source)
+  }
+}

--- a/src/blob/disk.js
+++ b/src/blob/disk.js
@@ -1,0 +1,66 @@
+import { writeFile, mkdir } from 'node:fs/promises'
+import { openAsBlob } from 'node:fs'
+import { Task } from 'datalogia'
+
+/**
+ * @typedef {object} Model
+ * @property {URL} url
+ *
+ * @param {Model} options
+ */
+export function* open(options) {
+  yield* Task.wait(mkdir(options.url, { recursive: true }))
+  return new BlobStore(options)
+}
+
+/**
+ * @param {Model} store
+ * @param {string} key
+ * @param {Blob} blob
+ * @returns {Task.Task<{}, Error>}
+ */
+export function* put({ url }, key, blob) {
+  const target = new URL(`${key}`, url)
+  console.log(`Writing to ${target}`)
+  const write = writeFile(target, blob.stream())
+  yield* Task.wait(write)
+  console.log(`Wrote to ${target}`)
+  return {}
+}
+
+/**
+ *
+ * @param {Model} store
+ * @param {string} key
+ * @returns {Task.Task<Blob, Error>}
+ */
+export function* get({ url }, key) {
+  const blob = yield* Task.wait(openAsBlob(new URL(`./${key}`, url)))
+  return blob
+}
+
+class BlobStore {
+  #options
+  /**
+   * @param {Model} options
+   */
+  constructor(options) {
+    this.#options = options
+  }
+  get url() {
+    return this.#options.url
+  }
+  /**
+   * @param {string} key
+   * @param {Blob} blob
+   */
+  put(key, blob) {
+    return put(this, key, blob)
+  }
+  /**
+   * @param {string} key
+   */
+  get(key) {
+    return get(this, key)
+  }
+}

--- a/src/blob/disk.js
+++ b/src/blob/disk.js
@@ -21,10 +21,8 @@ export function* open(options) {
  */
 export function* put({ url }, key, blob) {
   const target = new URL(`${key}`, url)
-  console.log(`Writing to ${target}`)
   const write = writeFile(target, blob.stream())
   yield* Task.wait(write)
-  console.log(`Wrote to ${target}`)
   return {}
 }
 

--- a/src/blob/memory.js
+++ b/src/blob/memory.js
@@ -31,7 +31,7 @@ export function* get({ blobs }, key) {
   if (blob) {
     return blob
   } else {
-    throw new RangeError(`Blob ${key} not found`)
+    throw new RangeError(`Blob ${key} was not found`)
   }
 }
 

--- a/src/blob/memory.js
+++ b/src/blob/memory.js
@@ -1,0 +1,62 @@
+import * as Type from '../replica/type.js'
+
+/**
+ * @typedef {object} Self
+ * @property {Map<string, Blob>} blobs
+ *
+ * @param {{}} options
+ */
+export function* open(options = {}) {
+  return new BlobStore()
+}
+
+/**
+ * @param {Self} self
+ * @param {string} key
+ * @param {Blob} blob
+ */
+export function* put({ blobs }, key, blob) {
+  blobs.set(key, blob)
+  return {}
+}
+
+/**
+ *
+ * @param {Self} self
+ * @param {string} key
+ */
+
+export function* get({ blobs }, key) {
+  const blob = blobs.get(key)
+  if (blob) {
+    return blob
+  } else {
+    throw new RangeError(`Blob ${key} not found`)
+  }
+}
+
+/**
+ * @implements {Type.BlobStore}
+ */
+class BlobStore {
+  /**
+   * @param {Map<string, Blob>} blobs
+   */
+  constructor(blobs = new Map()) {
+    this.blobs = blobs
+  }
+  /**
+   *
+   * @param {string} key
+   * @param {Blob} blob
+   */
+  put(key, blob) {
+    return put(this, key, blob)
+  }
+  /**
+   * @param {string} key
+   */
+  get(key) {
+    return get(this, key)
+  }
+}

--- a/src/replica/query.js
+++ b/src/replica/query.js
@@ -7,6 +7,8 @@ import { Var } from 'datalogia'
 import { Reference } from 'merkle-reference'
 import Scope from './query/scope.js'
 
+export const contentType = `application/synopsys-query+json`
+
 /**
  * Takes JSON formatted query and return a query object with variables
  * expected by the database.

--- a/src/replica/selection.js
+++ b/src/replica/selection.js
@@ -5,6 +5,8 @@ import * as Type from './type.js'
 import { of as refer } from '../datum/reference.js'
 import * as UTF8 from '../utf8.js'
 
+export const contentType = `application/synopsys+json`
+
 /**
  * @param {ReadableStream<Type.Selection<Type.Selector>[]>} source
  */

--- a/src/replica/session/local.js
+++ b/src/replica/session/local.js
@@ -71,7 +71,7 @@ class LocalSource extends ReadableStream {
         // get a selection forward it downstream and break the loop until the
         // next pull from the subscriber.
         while (!this.cancelled) {
-          const poll = Task.perform(this.poll())
+          const poll = Task.perform(this.poll(subscriber))
           const selection = await poll
           // If we got a selection we enqueue it to the subscriber and break the
           // loop.
@@ -99,7 +99,11 @@ class LocalSource extends ReadableStream {
     this.session = options.session
   }
 
-  *poll() {
+  /**
+   * @param {ReadableStreamDefaultController} subscriber
+   * @returns
+   */
+  *poll(subscriber) {
     // If we have revision we wait for the new session commit before we
     // re-evaluate the query. If we don not have revision yet we want to
     // evaluate the query immediately.
@@ -114,7 +118,13 @@ class LocalSource extends ReadableStream {
       }
     }
 
-    const selection = yield* DB.query(this.session.store, this.query)
+    const result = yield* DB.query(this.session.store, this.query).result()
+    if (result.error) {
+      subscriber.close()
+      this.cancelled = true
+      return null
+    }
+    const selection = result.ok
     // If stream was cancelled while we were evaluating a query we abort as
     // subscriber is no longer interested in the results.
     ///* c8 ignore next 3 */ not sure how to test this

--- a/src/replica/session/local.js
+++ b/src/replica/session/local.js
@@ -6,7 +6,7 @@ import { broadcast, channel } from '../sync.js'
 
 /**
  * @typedef {object} Open
- * @property {Type.Store} source.store
+ * @property {Type.DataStore} source.store
  */
 
 /**
@@ -16,7 +16,7 @@ import { broadcast, channel } from '../sync.js'
  * stop listening for commits.
  *
  * @typedef {object} LocalSession
- * @property {Type.Store} store
+ * @property {Type.DataStore} store
  * @property {Type.Reader<Type.Commit, never>} transaction
  */
 
@@ -158,7 +158,7 @@ export function* transact(session, changes) {
 class Local {
   /**
    *
-   * @param {Type.Store} store
+   * @param {Type.DataStore} store
    */
   constructor(store) {
     this.store = store

--- a/src/replica/subscription.js
+++ b/src/replica/subscription.js
@@ -1,0 +1,1 @@
+export const contentType = `text/event-stream`

--- a/src/replica/type.ts
+++ b/src/replica/type.ts
@@ -27,14 +27,22 @@ import type {
   API,
 } from 'datalogia'
 import type { Invocation, Task } from 'datalogia/task'
-import type { Commit, Database as Store } from '../store/okra.js'
+import type { Commit, Database as DataStore } from '../store/okra.js'
 import { Phantom } from 'multiformats'
 
 export type Constant = API.Constant
 
-export { Store, Commit }
+export { DataStore, Commit }
 export type Revision = { id: string }
 
+export interface BlobReader {
+  get(key: string): Task<Blob, Error>
+}
+export interface BlobWriter {
+  put(key: string, blob: Blob): Task<{}, Error>
+}
+
+export interface BlobStore extends BlobReader, BlobWriter {}
 /**
  * A directed acyclic graph.
  */

--- a/src/service.js
+++ b/src/service.js
@@ -5,6 +5,8 @@ export * as DB from 'datalogia'
 import * as Replica from './replica.js'
 import * as Reference from './datum/reference.js'
 import * as Query from './replica/query.js'
+import * as Subscription from './replica/subscription.js'
+import * as Selection from './replica/selection.js'
 import { refer, synopsys } from './replica.js'
 import { toEventSource } from './replica/selection.js'
 import { broadcast } from './replica/sync.js'
@@ -13,34 +15,37 @@ import * as DAG from './replica/dag.js'
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH',
-  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Headers': 'Content-Type, Range, Accept',
 }
 
 /**
  * Connects to the  service by opening the underlying store.
  *
  * @param {object} source
- * @param {Replica.Store} source.store
+ * @param {Replica.DataStore} source.data
+ * @param {Replica.BlobStore} source.blobs
  * @returns {Task.Task<Service, Error>}
  */
-export const open = function* ({ store }) {
-  const replica = yield* Replica.open({ local: { store } })
-  const revision = yield* store.status()
+export const open = function* ({ data, blobs }) {
+  const replica = yield* Replica.open({ local: { store: data } })
+  const revision = yield* data.status()
 
-  return new Service(replica, store, revision)
+  return new Service(replica, data, blobs, revision)
 }
 
 export class Service {
   /**
    * @param {Replica.Revision} revision
    * @param {Replica.Replica} replica
-   * @param {Replica.Store} store
+   * @param {Replica.DataStore} data
+   * @param {Replica.BlobStore} blobs
    * @param {Map<string, ReturnType<broadcast>>} subscriptions
    *
    */
-  constructor(replica, store, revision, subscriptions = new Map()) {
+  constructor(replica, data, blobs, revision, subscriptions = new Map()) {
     this.replica = replica
-    this.store = store
+    this.data = data
+    this.blobs = blobs
     this.revision = revision
     this.subscriptions = subscriptions
 
@@ -61,7 +66,7 @@ export class Service {
  * @param {MutableSelf} self
  */
 export const close = function* (self) {
-  yield* self.store.close()
+  yield* self.data.close()
 }
 
 /**
@@ -78,6 +83,8 @@ export const fetch = function* (self, request) {
         statusText: 'YOLO',
         headers: CORS,
       })
+    case 'HEAD':
+      return yield* head(self, request)
     case 'PUT':
       return yield* put(self, request)
     case 'PATCH':
@@ -94,6 +101,16 @@ export const fetch = function* (self, request) {
 
 /**
  * @param {MutableSelf} self
+ * @param {Replica.Transaction} changes
+ */
+export function* transact(self, changes) {
+  const commit = yield* self.replica.transact(changes)
+  self.revision = commit.after
+  return commit
+}
+
+/**
+ * @param {MutableSelf} self
  * @param {Request} request
  */
 export function* patch(self, request) {
@@ -102,8 +119,7 @@ export function* patch(self, request) {
     const changes = /** @type {DB.Transaction} */ (
       yield* DAG.decode(JSON, body)
     )
-    const commit = yield* self.replica.transact(changes)
-    self.revision = commit.after
+    const commit = yield* transact(self, changes)
     return yield* ok({
       before: commit.before,
       after: commit.after,
@@ -136,12 +152,31 @@ export function* patch(self, request) {
  * @returns {Task.Task<Response, Error>}
  */
 export function* put(self, request) {
+  const contentType = request.headers.get('content-type')
+
+  switch (contentType) {
+    case Query.contentType:
+      return yield* importQuery(self, request)
+    case 'application/json':
+      return yield* importJSON(self, request)
+    default:
+      return yield* importBlob(self, request)
+  }
+}
+
+/**
+ * @param {MutableSelf} self
+ * @param {Request} request
+ * @returns {Task.Task<Response, Error>}
+ */
+export function* importQuery(self, request) {
   const body = new Uint8Array(yield* Task.wait(request.arrayBuffer()))
+
   try {
     const query = refer(yield* Query.fromBytes(body))
     if (!self.subscriptions.get(query.toString())) {
       // Check if we have this query stored in the database already.
-      const selection = yield* DB.query(self.store, {
+      const selection = yield* DB.query(self.data, {
         select: {},
         where: [{ Case: [synopsys, 'synopsys/query', query] }],
       })
@@ -150,7 +185,7 @@ export function* put(self, request) {
       // we probably want to store actual query into a blob but this will do
       // for now.
       if (selection.length === 0) {
-        yield* DB.transact(self.store, [
+        yield* DB.transact(self.data, [
           { Assert: [synopsys, 'synopsys/query', query] },
           { Assert: [query, 'blob/content', body] },
         ])
@@ -177,13 +212,86 @@ export function* put(self, request) {
 }
 
 /**
+ * @param {MutableSelf} self
+ * @param {Request} request
+ * @returns {Task.Task<Response, Error>}
+ */
+export function* importJSON(self, request) {
+  const body = new Uint8Array(yield* Task.wait(request.arrayBuffer()))
+  try {
+    const json = yield* DAG.decode(JSON, body)
+    const commit = yield* transact(
+      self,
+      /** @type {Replica.Transaction} */ ([{ Import: json }])
+    )
+    return yield* ok({
+      before: commit.before,
+      after: commit.after,
+    })
+  } catch (reason) {
+    return yield* error(
+      { message: /** @type {Error} */ (reason).message },
+      {
+        status: 400,
+        statusText: 'Invalid JSON payload',
+      }
+    )
+  }
+}
+
+/**
+ * @param {MutableSelf} self
+ * @param {Request} request
+ * @returns {Task.Task<Response, Error>}
+ */
+export function* importBlob(self, request) {
+  const blob = yield* Task.wait(request.blob())
+  try {
+    const buffer = yield* Task.wait(blob.arrayBuffer())
+    const id = refer(new Uint8Array(buffer))
+
+    yield* self.blobs.put(id.toString(), blob)
+    const contentType =
+      request.headers.get('content-type') ?? 'application/octet-stream'
+
+    const commit = yield* transact(self, [
+      { Assert: [id, `content/type`, contentType] },
+      { Assert: [id, `content/length`, blob.size] },
+    ])
+
+    return yield* ok(
+      {
+        before: commit.before,
+        after: commit.after,
+      },
+      {
+        status: 303,
+        headers: {
+          ...CORS,
+          location: new URL(`/${id}`, request.url).toString(),
+        },
+      }
+    )
+  } catch (reason) {
+    return yield* error(
+      { message: /** @type {Error} */ (reason).message },
+      {
+        status: 400,
+        statusText: 'Invalid JSON payload',
+      }
+    )
+  }
+}
+
+/**
  * @typedef {object} Self
  * @property {Replica.Revision} revision - Current revision of the store.
- * @property {DB.API.Querier} store - The underlying data store.
+ * @property {DB.API.Querier} data - The underlying data store.
+ * @property {Replica.BlobReader} blobs
  * @property {Map<string, ReturnType<broadcast>>} subscriptions - Active query sessions.
  * @property {Replica.Replica} replica
  *
- * @typedef {Self & {store: Replica.Store}} MutableSelf
+ * @typedef {Self & {data: Replica.DataStore, blobs: Replica.BlobStore}} MutableSelf
  */
 
 /**
@@ -197,7 +305,7 @@ export const subscribe = function* (self, id) {
     return channel
   } else {
     const { content } = Replica.$
-    const [selection] = yield* DB.query(self.store, {
+    const [selection] = yield* DB.query(self.data, {
       select: { content },
       where: [{ Case: [id, 'blob/content', content] }],
     })
@@ -216,13 +324,95 @@ export const subscribe = function* (self, id) {
 }
 
 /**
+ * @template {DB.Selector} [Select=DB.Selector]
+ * @param {Self} self
+ * @param {Replica.Reference<Replica.Query<Select>>} id
+ */
+export function* query(self, id) {
+  const { content } = Replica.$
+  const [match] = yield* DB.query(self.data, {
+    select: { content },
+    where: [{ Case: [id, 'blob/content', content] }],
+  })
+  const bytes = match?.content
+  const query = bytes ? yield* Query.fromBytes(bytes) : null
+  const selection = query ? yield* DB.query(self.data, query) : null
+  if (selection) {
+    return selection
+  } else {
+    throw new RangeError(`Query ${id} was not found`)
+  }
+}
+
+/**
+ * @param {Self} self
+ * @param {Request} request
+ */
+export const head = function* (self, request) {
+  const url = new URL(request.url)
+  try {
+    const id = Reference.fromString(url.pathname.slice(1))
+    const { type, size } = Replica.$
+    const [match] = yield* DB.query(self.data, {
+      select: { type, size },
+      where: [
+        { Case: [id, 'content/type', type] },
+        { Case: [id, 'content/length', size] },
+      ],
+    })
+
+    if (match) {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          ...CORS,
+          'content-type': match.type,
+          'content-length': match.size,
+        },
+      })
+    } else {
+      return yield* error(
+        { message: `Content ${id} not found` },
+        { status: 404 }
+      )
+    }
+  } catch (reason) {
+    return yield* error({ message: Object(reason).message }, { status: 404 })
+  }
+}
+
+/**
+ * @param {Self} self
+ * @param {Request} request
+ */
+export const get = function* (self, request) {
+  // If we land on the root URL we just return an empty response.
+  const url = new URL(request.url)
+  if (url.pathname === '/') {
+    return yield* ok({}, { status: 404 })
+  }
+  const accept =
+    request.headers.get('content-type') ?? 'application/octet-stream'
+
+  switch (accept) {
+    case Selection.contentType:
+    case 'application/json':
+      return yield* getSelection(self, request)
+    case Subscription.contentType:
+      return yield* getSubscription(self, request)
+    default:
+      return yield* getBlob(self, request)
+  }
+}
+
+/**
  * Subscribes to the session by opening a new event source connection and
  * adding it to the list of subscribers.
  *
  * @param {Self} self
  * @param {Request} request
  */
-export const get = function* (self, request) {
+export function* getSubscription(self, request) {
   // If we land on the root URL we just return an empty response.
   const url = new URL(request.url)
   if (url.pathname === '/') {
@@ -254,6 +444,72 @@ export const get = function* (self, request) {
       { message: `Query ${id} was not found` },
       { status: 404 }
     )
+  }
+}
+
+/**
+ * @param {Self} self
+ * @param {Request} request
+ */
+export function* getSelection(self, request) {
+  // If we land on the root URL we just return an empty response.
+  const url = new URL(request.url)
+  const id = url.pathname.slice(1)
+  const source = Reference.fromString(id, null)
+  if (source == null) {
+    return yield* error(
+      { message: `Query ${id} was not found` },
+      { status: 404 }
+    )
+  }
+  try {
+    const selection = yield* query(self, source)
+    return new Response(yield* DAG.encode(JSON, selection), {
+      status: 200,
+      headers: {
+        ...CORS,
+        'Content-Type': Selection.contentType,
+      },
+    })
+  } catch (reason) {
+    return yield* error({ message: Object(reason).message }, { status: 404 })
+  }
+}
+
+/**
+ * @param {Self} self
+ * @param {Request} request
+ */
+export function* getBlob(self, request) {
+  const url = new URL(request.url)
+  const id = url.pathname.slice(1)
+  try {
+    const range = request.headers.get('range')
+    const blob = yield* self.blobs.get(id)
+    if (range) {
+      const [start, end] = range.slice(6).split('-').map(Number)
+      const slice = blob.slice(start, end === 0 ? blob.size : end)
+      return new Response(slice, {
+        status: 206,
+        headers: {
+          ...CORS,
+          'Content-Type': blob.type,
+          'Content-Length': `${slice.size}`,
+          'Content-Range': `bytes ${start}-${start + slice.size}/${blob.size}`,
+        },
+      })
+    } else {
+      return new Response(blob, {
+        status: 200,
+        headers: {
+          ...CORS,
+          'Content-Length': `${blob.size}`,
+          'Content-Type': blob.type,
+        },
+      })
+    }
+  } catch (reason) {
+    return yield* error({ message: Object(reason).message }, { status: 404 })
   }
 }
 

--- a/test/remote.spec.js
+++ b/test/remote.spec.js
@@ -1,6 +1,7 @@
 import * as DB from 'datalogia'
 import { Task, Replica, refer, $ } from 'synopsys'
-import * as Memory from 'synopsys/store/memory'
+import * as Store from 'synopsys/store/memory'
+import * as Blobs from 'synopsys/blob/memory'
 import * as Service from 'synopsys/service'
 import * as Subscription from './subscription.js'
 
@@ -13,8 +14,9 @@ export const testRemote = {
   transaction: {
     basic: (assert) =>
       Task.spawn(function* () {
-        const store = yield* Memory.open()
-        const service = yield* Service.open({ store })
+        const store = yield* Store.open()
+        const blobs = yield* Blobs.open()
+        const service = yield* Service.open({ data: store, blobs })
 
         const remote = yield* Replica.open({
           remote: {
@@ -40,8 +42,9 @@ export const testRemote = {
 
     'invalid transaction': (assert) =>
       Task.spawn(function* () {
-        const store = yield* Memory.open()
-        const service = yield* Service.open({ store })
+        const store = yield* Store.open()
+        const blobs = yield* Blobs.open()
+        const service = yield* Service.open({ data: store, blobs })
 
         const remote = yield* Replica.open({
           remote: {
@@ -64,8 +67,9 @@ export const testRemote = {
   subscription: Subscription.testSubscription({
     connect: () =>
       Task.spawn(function* () {
-        const store = yield* Memory.open()
-        const service = yield* Service.open({ store })
+        const store = yield* Store.open()
+        const blobs = yield* Blobs.open()
+        const service = yield* Service.open({ data: store, blobs })
         const replica = yield* Replica.open({
           remote: {
             url: new URL('http://localhost:8080'),

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -1,5 +1,6 @@
 import * as DB from 'datalogia'
-import * as Memory from 'synopsys/store/memory'
+import * as Store from 'synopsys/store/memory'
+import * as Blobs from 'synopsys/blob/memory'
 import { Task, Replica, refer, $ } from 'synopsys'
 import * as Service from 'synopsys/service'
 
@@ -10,7 +11,8 @@ export const testService = {
   'options request': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const options = yield* Service.fetch(
@@ -34,7 +36,8 @@ export const testService = {
   'patch transacts data': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const counter = refer({ counter: {} })
@@ -56,7 +59,8 @@ export const testService = {
   'unsupported method': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const unsupported = yield* Service.fetch(
@@ -73,7 +77,8 @@ export const testService = {
   'GET /': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const get = yield* Service.fetch(
@@ -91,7 +96,8 @@ export const testService = {
   'GET /jibberish': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const get = yield* Service.fetch(
@@ -108,7 +114,8 @@ export const testService = {
   'rejects invalid query': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const put = yield* Service.fetch(
@@ -130,7 +137,8 @@ export const testService = {
   'saves good query': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const put = yield* Service.fetch(
@@ -152,7 +160,7 @@ export const testService = {
         `http://localhost:8080/ba4jcbkpzhfmtjxocg7ztwchbgzzjabb36wko2iqzlpikhlrga2cttoef`
       )
 
-      const found = yield* DB.query(service.store, {
+      const found = yield* DB.query(service.data, {
         select: { query: $.query },
         where: [{ Case: [Replica.synopsys, 'synopsys/query', $.query] }],
       })
@@ -166,7 +174,8 @@ export const testService = {
   'returns event source when getting query': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const put = yield* Service.fetch(
@@ -219,7 +228,8 @@ data:[{"query":{"/":"baedreigpx7y7rjahspwuhq2nu4rdgv2y5omzmktwf5eb3ybqk5fqundvmy
   'fails to find query': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const get = yield* Service.fetch(
@@ -240,7 +250,8 @@ data:[{"query":{"/":"baedreigpx7y7rjahspwuhq2nu4rdgv2y5omzmktwf5eb3ybqk5fqundvmy
   'concurrent subscriptions': (assert) =>
     Task.spawn(function* () {
       const service = yield* Service.open({
-        store: yield* Memory.open(),
+        data: yield* Store.open(),
+        blobs: yield* Blobs.open(),
       })
 
       const put = yield* Service.fetch(


### PR DESCRIPTION
1. Extends PUT method so that user can send a service a
   - JSON file which is import it into db when `content-type: application/json` is used.
   - Arbitrary blob and import it into blob store unless `content-type: application/synopsys-query+json` is used.
   - ⚠️ To subscribe client now needs to set `content-type: application/synopsys-query+json` and `accept: text/event-stream` headers.
   - Client can now also store query without subscribing using `content-type: application/synopsys-query+json` and `accept: text/json` headers.

2. Adds HEAD method so that client can get metadata on stored blobs
3. Extends GET method so that user can:
   - Fetch or embed blobs
   - Make HTTP Range requests
   - Get subscription via `accept: text/event-stream` header.
   - Get query selection without subscribing via `accept: application/json` header.