### PR TITLE
fix: broadcast last value to new connection

### DIFF
--- a/src/replica/sync.js
+++ b/src/replica/sync.js
@@ -117,6 +117,8 @@ export class BroadcastStream {
   #ports
   #source
   #task
+  /** @type {T|undefined} */
+  #last
   /**
    * @param {ReadableStream<T>} source
    * @param {Set<ReadableStreamDefaultController<T>>} [ports]
@@ -137,6 +139,7 @@ export class BroadcastStream {
    * @param {T} chunk
    */
   write(chunk) {
+    this.#last = chunk
     for (const port of this.#ports) {
       port.enqueue(chunk)
     }
@@ -168,6 +171,9 @@ export class BroadcastStream {
    */
   connect(port) {
     this.#ports.add(port)
+    if (this.#last !== undefined) {
+      port.enqueue(this.#last)
+    }
   }
   /**
    * @param {ReadableStreamDefaultController<T>} port

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -332,11 +332,19 @@ data:[]\n\n`
         const body = /** @type {ReadableStream<Uint8Array>} */ (concurrent.body)
         const reader = body.getReader()
 
-        const chunk = yield* Task.wait(reader.read())
-        const content = new TextDecoder().decode(chunk?.value)
+        const firstChunk = yield* Task.wait(reader.read())
 
         assert.equal(
-          content,
+          new TextDecoder().decode(firstChunk?.value),
+          `id:ba4jca7pcf7obj4jijrrgmgzo642qydb7cstlwpv7vf7oudqyrpwhowxx
+event:change
+data:[]\n\n`
+        )
+
+        const secondChunk = yield* Task.wait(reader.read())
+
+        assert.equal(
+          new TextDecoder().decode(secondChunk?.value),
           `id:ba4jcapk7kku4u32tw7sx63wuup2glg2wqspvo356b62k3bzwcfcntdwt
 event:change
 data:[{"count":1}]\n\n`

--- a/test/sync.spec.js
+++ b/test/sync.spec.js
@@ -64,7 +64,7 @@ export const testSync = {
     writer.close()
 
     assert.deepEqual(await first, [{ ok: 1 }, { ok: 2 }])
-    assert.deepEqual(await second, [{ ok: 2 }])
+    assert.deepEqual(await second, [{ ok: 1 }, { ok: 2 }])
   },
 
   'cancel broadcast': async (assert) => {
@@ -78,7 +78,7 @@ export const testSync = {
 
     const second = collect(hub.fork())
 
-    writer.write(2)
+    await writer.write(2)
 
     writer.abort(new Error('Terminate'))
 
@@ -88,6 +88,7 @@ export const testSync = {
       { error: new Error('Terminate') },
     ])
     assert.deepEqual(await second, [
+      { ok: 1 },
       { ok: 2 },
       { error: new Error('Terminate') },
     ])


### PR DESCRIPTION
Rebroadcasts last query match to new connections