### PR TITLE
feat!: implement sync protocol

### DIFF
--- a/src/differential.js
+++ b/src/differential.js
@@ -1,0 +1,97 @@
+import * as Type from './replica/type.js'
+import { Task } from 'datalogia'
+import { sync } from '@canvas-js/okra'
+
+/**
+ * @typedef {object} Delta
+ * @property {Type.Change[]} local
+ * @property {Type.Change[]} remote
+ */
+
+/**
+ * Calculates the changes between local and remote databases.
+ *
+ * @param {Type.TreeReader} local
+ * @param {Type.PullSource} remote
+ * @param {(key: Uint8Array, source: Uint8Array, target: Uint8Array) => Task.Task<Uint8Array>} merge
+ */
+export function* differentiate(local, remote, merge) {
+  /** @type {Delta} */
+  const changes = { local: [], remote: [] }
+  /** @type {Type.ReadOnlyTransaction} */
+  const target = /** @type {any} */ (new SyncTarget(local))
+  const source = new SyncSource(remote)
+  const delta = sync(source, target)
+  while (true) {
+    const next = yield* Task.wait(delta.next())
+    if (next.done) {
+      break
+    }
+    const { key, source, target } = next.value
+    if (source != null && target != null) {
+      const value = yield* merge(key, source, target)
+      changes.local.push([key, value])
+      changes.remote.push([key, value])
+    } else if (target != null) {
+      changes.remote.push([key, target])
+    } else if (source != null) {
+      changes.local.push([key, source])
+    }
+  }
+
+  return changes
+}
+
+class SyncSource {
+  /**
+   * @param {Type.PullSource} source
+   */
+  constructor(source) {
+    this.source = source
+  }
+  getRoot() {
+    return Task.perform(this.source.getRoot())
+  }
+  /**
+   * @param {number} level
+   * @param {Uint8Array} key
+   */
+  getNode(level, key) {
+    return Task.perform(this.source.getNode(level, key))
+  }
+  /**
+   * @param {number} level
+   * @param {Uint8Array} key
+   */
+  getChildren(level, key) {
+    return Task.perform(this.source.getChildren(level, key))
+  }
+}
+
+class SyncTarget extends SyncSource {
+  /**
+   *
+   * @param {Type.TreeReader} reader
+   */
+  constructor(reader) {
+    super(reader)
+    this.reader = reader
+  }
+  /** @type {Type.TreeReader['nodes']} */
+  nodes(level, lowerBound, upperBound, options) {
+    return this.reader.nodes(level, lowerBound, upperBound, options)
+  }
+
+  get entries() {
+    throw new Error('Not implemented')
+  }
+  get has() {
+    throw new Error('Not implemented')
+  }
+  get get() {
+    throw new Error('Not implemented')
+  }
+  get keys() {
+    throw new Error('Not implemented')
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import * as HTTP from './http.js'
 import * as Service from './service.js'
 import * as Store from './store.js'
 import * as Blobs from './blob.js'
+import * as Sync from './sync.js'
 import process from 'node:process'
 
 export const KiB = 1024
@@ -23,11 +24,14 @@ export const main = function* ({
   store = process.env.STORE ?? '../service-store/',
 } = {}) {
   const url = new URL(store, import.meta.url)
+  const data = yield* Store.open({
+    url,
+    mapSize: storeSize,
+  })
+  const sync = yield* Sync.open(data.tree)
   const service = yield* Service.open({
-    data: yield* Store.open({
-      url,
-      mapSize: storeSize,
-    }),
+    sync,
+    data,
     blobs: yield* Blobs.open({
       url: new URL('./blobs/', `${url}`),
     }),

--- a/src/replica/type.ts
+++ b/src/replica/type.ts
@@ -18,6 +18,10 @@ export type {
 export type { BlockEncoder, BlockDecoder } from 'multiformats'
 export type { Task } from 'datalogia/task'
 export * from '../store/type.js'
+export type {
+  Reader as TreeReader,
+  Writer as TreeWriter,
+} from '../store/type.js'
 import type {
   Selector,
   InferBindings as Selection,

--- a/src/service.js
+++ b/src/service.js
@@ -11,6 +11,7 @@ import { refer, synopsys } from './replica.js'
 import { toEventSource } from './replica/selection.js'
 import { broadcast } from './replica/sync.js'
 import * as DAG from './replica/dag.js'
+import * as Sync from './sync.js'
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -22,28 +23,31 @@ const CORS = {
  * Connects to the  service by opening the underlying store.
  *
  * @param {object} source
+ * @param {Sync.Service} [source.sync]
  * @param {Replica.DataStore} source.data
  * @param {Replica.BlobStore} source.blobs
  * @returns {Task.Task<Service, Error>}
  */
-export const open = function* ({ data, blobs }) {
+export const open = function* ({ data, blobs, sync }) {
   const replica = yield* Replica.open({ local: { store: data } })
   const revision = yield* data.status()
 
-  return new Service(replica, data, blobs, revision)
+  return new Service(replica, sync, data, blobs, revision)
 }
 
 export class Service {
   /**
    * @param {Replica.Revision} revision
    * @param {Replica.Replica} replica
+   * @param {Sync.Service|undefined} sync
    * @param {Replica.DataStore} data
    * @param {Replica.BlobStore} blobs
    * @param {Map<string, ReturnType<broadcast>>} subscriptions
    *
    */
-  constructor(replica, data, blobs, revision, subscriptions = new Map()) {
+  constructor(replica, sync, data, blobs, revision, subscriptions = new Map()) {
     this.replica = replica
+    this.sync = sync
     this.data = data
     this.blobs = blobs
     this.revision = revision
@@ -91,6 +95,8 @@ export const fetch = function* (self, request) {
       return yield* patch(self, request)
     case 'GET':
       return yield* get(self, request)
+    case 'POST':
+      return yield* post(self, request)
     default:
       return yield* error(
         { message: 'Method not allowed' },
@@ -161,6 +167,39 @@ export function* put(self, request) {
       return yield* importJSON(self, request)
     default:
       return yield* importBlob(self, request)
+  }
+}
+
+/**
+ * @param {MutableSelf} self
+ * @param {Request} request
+ */
+export function* post(self, request) {
+  const accept = request.headers.get('accept')
+  if (self.sync == null) {
+    return yield* error(
+      { message: 'Sync protocol is not available' },
+      { status: 400, statusText: 'Bad Request' }
+    )
+  }
+
+  switch (accept) {
+    case Sync.contentType:
+      return new Response(
+        request.body?.pipeThrough(Sync.synchronize(self.sync)),
+        {
+          status: 200,
+          headers: {
+            ...CORS,
+            contentType: Sync.contentType,
+          },
+        }
+      )
+    default:
+      return yield* error(
+        { message: 'Unsupported content type' },
+        { status: 400, statusText: 'Bad Request' }
+      )
   }
 }
 
@@ -291,7 +330,7 @@ export function* importBlob(self, request) {
  * @property {Map<string, ReturnType<broadcast>>} subscriptions - Active query sessions.
  * @property {Replica.Replica} replica
  *
- * @typedef {Self & {data: Replica.DataStore, blobs: Replica.BlobStore}} MutableSelf
+ * @typedef {Self & {sync?: Sync.Service, data: Replica.DataStore, blobs: Replica.BlobStore}} MutableSelf
  */
 
 /**

--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -1,0 +1,142 @@
+import * as Type from '../replica/type.js'
+import * as DAG from '../replica/dag.js'
+import * as JSON from '@ipld/dag-json'
+import { base64 } from 'multiformats/bases/base64'
+import { Task } from 'datalogia'
+import { get } from 'http'
+import { refer } from '../datum/reference.js'
+import { channel } from '../replica/sync.js'
+import * as Sync from '../sync.js'
+
+/**
+ * @typedef {(request: Request) => Promise<Response>} Fetch
+ *
+ * @typedef {object} Connection
+ * @property {URL} url
+ * @property {Fetch} [fetch]
+ */
+
+/**
+ * Opens a new remote session.
+ *
+ * @param {Connection} connection
+ */
+export const open = ({ url, fetch = globalThis.fetch.bind(globalThis) }) =>
+  RemoteSession.open({ url, fetch })
+
+class RemoteSession {
+  /**
+   * @param {Required<Connection>} connection
+   */
+  static *open(connection) {
+    const { readable, writable } = new TransformStream()
+    const request = new Request(connection.url, {
+      method: 'POST',
+      // @ts-expect-error - `duplex` is required but TS does not seem to
+      // know of it.
+      duplex: 'half',
+      headers: {
+        accept: Sync.contentType,
+      },
+      body: readable,
+    })
+
+    const response = yield* Task.wait(connection.fetch(request))
+    if (response.status !== 200 || !response.body) {
+      throw new Error('Failed to open session')
+    }
+
+    const session = new RemoteSession({ readable: response.body, writable })
+    Task.perform(session.poll())
+
+    return session
+  }
+
+  /**
+   * @param {object} channel
+   * @param {ReadableStream<Uint8Array>} channel.readable
+   * @param {WritableStream<Uint8Array>} channel.writable
+   */
+  constructor({ readable, writable }) {
+    this.readable = readable
+    this.writable = writable
+    this.writer = writable.getWriter()
+    this.reader = readable.getReader()
+
+    this.cause = refer({})
+    /** @type {Map<string, Type.Channel<unknown, Error>>} */
+    this.ports = new Map()
+  }
+  *poll() {
+    while (true) {
+      const { done, value } = yield* Task.wait(this.reader.read())
+      if (done) {
+        break
+      }
+
+      const { cause, result } = /** @type {Sync.Outcome} */ (
+        yield* DAG.decode(JSON, value)
+      )
+
+      const port = this.ports.get(cause.toString())
+      if (port) {
+        this.ports.delete(cause.toString())
+        if (result.ok !== undefined) {
+          port.write(result.ok)
+        } else {
+          port.cancel(/** @type {Error} */ (result.error))
+        }
+        port.write(result)
+      } else {
+        throw new Error('Received result for unknown command')
+      }
+    }
+  }
+  /**
+   * @param {Partial<Sync.Command>} command
+   * @returns {Task.Task<any, Error>}
+   */
+  *perform(command) {
+    const request = { ...command, cause: this.cause }
+    const port = channel()
+    const id = refer(request)
+
+    this.ports.set(id.toString(), port)
+    this.cause = id
+
+    this.writer.write(yield* DAG.encode(JSON, request))
+
+    return yield* port.read()
+  }
+
+  /**
+   * @returns {Task.Task<Type.Node, Error>}
+   */
+  getRoot() {
+    return this.perform({ getRoot: { cause: this.cause } })
+  }
+  /**
+   * @param {number} level
+   * @param {Uint8Array} key
+   * @returns {Task.Task<Type.Node|null, Error>}
+   */
+  getNode(level, key) {
+    return this.perform({ getNode: { level, key, cause: this.cause } })
+  }
+  /**
+   * @param {number} level
+   * @param {Uint8Array} key
+   * @returns {Task.Task<Type.Node[], Error>}
+   */
+  getChildren(level, key) {
+    return this.perform({ getChildren: { level, key, cause: this.cause } })
+  }
+
+  /**
+   * @param {Type.Change[]} changes
+   * @returns {Task.Task<Type.Node, Error>}
+   */
+  integrate(changes) {
+    return this.perform({ integrate: { changes, cause: this.cause } })
+  }
+}

--- a/src/store/idb.js
+++ b/src/store/idb.js
@@ -87,7 +87,7 @@ class FixedIDBTree extends IDBTree {
     // @ts-expect-error
     const tree = new this(store, options)
     await store.write(() => tree.initialize())
-    return tree
+    return /** @type {FixedIDBTree} */ (tree)
   }
   /** @type {IDBTree['entries']} */
   async *entries(lowerBound, upperBound, options) {

--- a/src/store/okra.js
+++ b/src/store/okra.js
@@ -13,8 +13,6 @@ import * as Type from './type.js'
 const { Bytes } = Constant
 export { Task, CBOR }
 
-const instances = new WeakMap()
-
 /**
  * Represents an opaque database type with a methods corresponding to the
  * static functions exported by this module.
@@ -24,6 +22,13 @@ const instances = new WeakMap()
  * @implements {Type.Database}
  */
 export class Database {
+  /**
+   *
+   * @param {Type.Store} tree
+   */
+  constructor(tree) {
+    this.tree = tree
+  }
   /**
    * @param {API.FactsSelector} [selector]
    */
@@ -71,21 +76,11 @@ class Revision {
 }
 
 /**
- * Resolves underlying Okra.Tree instance.
- *
- * @param {Database} database
- * @returns {Type.Store}
- */
-const tree = (database) => instances.get(database)
-
-/**
  *
  * @param {Type.Store} tree
  */
 export function* open(tree) {
-  const instance = new Database()
-  instances.set(instance, tree)
-  return instance
+  return new Database(tree)
 }
 
 /**
@@ -94,7 +89,7 @@ export function* open(tree) {
  * @param {Database} db
  */
 export const status = (db) =>
-  tree(db).read(function* (reader) {
+  db.tree.read(function* (reader) {
     const root = yield* reader.getRoot()
     return new Revision(root)
   })
@@ -106,7 +101,7 @@ export const status = (db) =>
  * @param {Database} db
  */
 export function* close(db) {
-  yield* tree(db).close()
+  yield* db.tree.close()
   return {}
 }
 
@@ -120,10 +115,10 @@ export function* close(db) {
  * @returns {API.Task<API.Datum[], Error>}
  */
 export const scan = (db, { entity, attribute, value } = {}) =>
-  tree(db).read((reader) => iterate(reader, { entity, attribute, value }))
+  db.tree.read((reader) => iterate(reader, { entity, attribute, value }))
 
 /**
- * @param {Type.EntryRange} entries
+ * @param {Type.AwaitIterable<Type.Entry>} entries
  */
 function* collectDatums(entries) {
   const results = []
@@ -142,7 +137,7 @@ function* collectDatums(entries) {
 }
 
 /**
- * @param {Type.EntryRange} entries
+ * @param {Type.AwaitIterable<Type.Entry>} entries
  * @param {SearchPath} path
  */
 function* collectMatchingDatums(entries, [_index, _entity, _attribute, value]) {
@@ -305,7 +300,7 @@ export const toSearchKey = ([index, group, subgroup, member]) => {
  * @returns {API.Task<Commit, Error>}
  */
 export const transact = (db, changes) =>
-  tree(db).write(function* (writer) {
+  db.tree.write(function* (writer) {
     const root = yield* writer.getRoot()
     const hash = root.hash
     const time = Date.now()
@@ -371,7 +366,7 @@ export function* retract(writer, fact, cause) {
 }
 
 /**
- * @param {Type.Writer} writer
+ * @param {Type.Editor} writer
  * @param {API.Fact} fact
  * @param {Reference.Reference<Change>} cause
  */

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1,8 +1,9 @@
-import { Task } from 'datalogia/task'
+import { Task, Invocation } from 'datalogia/task'
 import type {
   Node,
   Bound,
   Entry,
+  Key,
   Awaitable,
   ReadOnlyTransaction,
   ReadWriteTransaction,
@@ -22,14 +23,18 @@ export type {
   Datum,
   Transaction,
   Commit,
+  Node,
+  Key,
 }
 
-export interface EntryRange {
-  next(): Awaitable<IteratorResult<Entry>>
+export interface AwaitIterable<T> {
+  next(): Awaitable<IteratorResult<T>>
 }
 
 export interface Reader {
   getRoot(): Task<Node>
+  getNode(level: number, key: Uint8Array): Task<Node | null>
+  getChildren(level: number, key: Uint8Array): Task<Node[]>
 
   entries(
     lowerBound?: Bound<Uint8Array> | null,
@@ -37,25 +42,41 @@ export interface Reader {
     options?: {
       reverse?: boolean
     }
-  ): EntryRange
+  ): AwaitIterable<Entry>
+
+  nodes(
+    level: number,
+    lowerBound?: Bound<Key> | null,
+    upperBound?: Bound<Key> | null,
+    options?: {
+      reverse?: boolean
+    }
+  ): AwaitIterable<Node>
 
   get(key: Uint8Array): Task<Uint8Array | null>
 }
 
-export interface Writer extends Reader {
+export interface Writer {
   delete(key: Uint8Array): Task<void>
   set(key: Uint8Array, value: Uint8Array): Task<void>
+
+  integrate(changes: Change[]): Task<Node>
 }
 
+export interface Editor extends Reader, Writer {}
+
 export interface Store {
-  read<T>(read: (reader: Reader) => Task<T>): Task<T>
-  write<T>(write: (writer: Writer) => Task<T>): Task<T>
+  read<T, X extends Error>(read: (reader: Reader) => Task<T, X>): Task<T, X>
+  write<T, X extends Error>(write: (editor: Editor) => Task<T, X>): Task<T, X>
 
   close(): Task<void>
 }
 
 export interface AsyncSource {
   getRoot(): Promise<Node>
+  getNode(level: number, key: Uint8Array): Promise<Node | null>
+  getChildren(level: number, key: Uint8Array): Promise<Node[]>
+
   get(key: Uint8Array): Promise<Uint8Array | null>
   set(key: Uint8Array, value: Uint8Array): Promise<void>
   delete(key: Uint8Array): Promise<void>
@@ -64,14 +85,49 @@ export interface AsyncSource {
     upperBound?: Bound<Uint8Array> | null,
     options?: { reverse?: boolean | undefined }
   ): AsyncIterableIterator<[Uint8Array, Uint8Array]>
+  nodes(
+    level: number,
+    lowerBound?: Bound<Key> | null,
+    upperBound?: Bound<Key> | null,
+    options?: {
+      reverse?: boolean
+    }
+  ): AsyncIterableIterator<Node>
 
   close?: () => Awaitable<void>
 }
 
 export interface Database {
+  tree: Store
+
   scan(selector: FactsSelector): Task<Datum[], Error>
   transact(charges: Transaction): Task<Commit, Error>
   status(): Task<Revision, Error>
 
   close(): Task<{}, Error>
 }
+
+export interface Root {
+  level: number
+  key: Uint8Array
+
+  hash: Uint8Array
+}
+
+export type Change = Assign | Remove
+
+export type Assign = [key: Uint8Array, value: Uint8Array]
+export type Remove = [key: Uint8Array]
+
+export interface PullSource {
+  getRoot(): Task<Node, Error>
+  getNode(level: number, key: Uint8Array): Task<Node | null, Error>
+
+  getChildren(level: number, key: Uint8Array): Task<Node[], Error>
+}
+
+export interface PushSource {
+  integrate(changes: Change[]): Task<Node, Error>
+}
+
+export interface SynchronizationSource extends PullSource, PushSource {}

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,0 +1,148 @@
+import * as Type from './replica/type.js'
+import { transform } from './replica/sync.js'
+import * as DAG from './replica/dag.js'
+import * as JSON from '@ipld/dag-json'
+import { Task } from 'datalogia'
+import { refer } from './datum/reference.js'
+import { error } from 'console'
+
+export const contentType = 'application/okra-sync'
+
+class Synchronizer {
+  /**
+   * @param {Type.Store} source
+   */
+  constructor(source) {
+    this.source = source
+    /** @type {TransformStream[]} */
+    this.queue = []
+    /** @type {Type.Variant<{idle:{}, busy:{}}>}  */
+    this.status = { idle: {} }
+  }
+  /**
+   *
+   * @param {TransformStream} channel
+   */
+  *enqueue({ readable, writable }) {
+    this.queue.push({ readable, writable })
+    yield* this.resume()
+  }
+  *resume() {
+    if (this.status.idle) {
+      this.status = { busy: {} }
+      yield* Task.sleep(0)
+      while (this.queue.length > 0) {
+        const { readable, writable } = this.queue[0]
+        this.queue.shift()
+        yield* this.source.write(function* (writer) {
+          const task = interpret(
+            writer,
+            readable.getReader(),
+            writable.getWriter()
+          )
+          return yield* Task.result(task)
+        })
+      }
+      this.status = { idle: {} }
+    }
+  }
+}
+
+/**
+ * @typedef {Synchronizer} Service
+ */
+
+/**
+ * @param {Type.Store} source
+ */
+export function* open(source) {
+  return new Synchronizer(source)
+}
+
+/**
+ * @param {Synchronizer} self
+ */
+export function synchronize(self) {
+  const { readable: input, writable } = new TransformStream()
+  const { readable, writable: output } = new TransformStream()
+
+  Task.perform(self.enqueue({ readable: input, writable: output }))
+
+  return { writable, readable }
+}
+
+/**
+ * @typedef {Type.Variant<{
+ *   getRoot: { cause: Type.Reference },
+ *   getNode: { cause: Type.Reference, key: Uint8Array, level: number },
+ *   getChildren: { cause: Type.Reference, key: Uint8Array, level: number },
+ *   integrate: { cause: Type.Reference, changes: Type.Change[] },
+ * }>} Command
+ *
+ * @typedef {object} Outcome
+ * @property {Type.Result} result
+ * @property {Type.Reference} cause
+ */
+
+/**
+ *
+ * @param {Uint8Array} bytes
+ */
+function* toCommand(bytes) {
+  const command = yield* DAG.decode(JSON, bytes)
+  return /** @type {Command} */ (command)
+}
+
+/**
+ *
+ * @param {Type.PullSource & Type.PushSource} store
+ * @param {ReadableStreamDefaultReader<Uint8Array>} input
+ * @param {WritableStreamDefaultWriter<Uint8Array>} output
+ */
+export function* interpret(store, input, output) {
+  while (true) {
+    const next = yield* Task.wait(input.read())
+    if (next.done) {
+      return yield* Task.wait(output.close())
+    } else {
+      const command = yield* toCommand(next.value)
+      const cause = refer(command)
+      const result = yield* Task.result(perform(store, command))
+      const response = result.ok
+        ? { result, cause }
+        : {
+            cause,
+            result: {
+              error: {
+                message: result.error?.message ?? 'Unknown error',
+                ...(result.error?.stack ? { stack: result.error.stack } : {}),
+              },
+            },
+          }
+      const payload = yield* DAG.encode(JSON, response)
+      yield* Task.wait(output.write(payload))
+    }
+  }
+}
+
+/**
+ * @param {Type.PullSource & Type.PushSource} store
+ * @param {Command} command
+ */
+
+function* perform(store, command) {
+  if (command.getRoot) {
+    return yield* store.getRoot()
+  } else if (command.getNode) {
+    return yield* store.getNode(command.getNode.level, command.getNode.key)
+  } else if (command.getChildren) {
+    return yield* store.getChildren(
+      command.getChildren.level,
+      command.getChildren.key
+    )
+  } else if (command.integrate) {
+    return yield* store.integrate(command.integrate.changes)
+  } else {
+    throw new Error('Unknown command')
+  }
+}

--- a/test/replication.spec.js
+++ b/test/replication.spec.js
@@ -1,0 +1,51 @@
+import { transact, query, Var, match, not, API } from 'datalogia'
+import { refer, Task, $, Type, Replica } from 'synopsys'
+import * as Hybrid from 'synopsys/store/hybrid'
+import * as Memory from 'synopsys/store/memory'
+import HybridSuite from './hybrid.js'
+import * as Store from '../src/store/okra.js'
+import * as Service from '../src/service.js'
+import * as Blobs from 'synopsys/blob/memory'
+import * as Remote from '../src/source/remote.js'
+import * as Sync from '../src/sync.js'
+/**
+ * @type {import('entail').Suite}
+ */
+export const testSync = {
+  'test sync protocol': (assert) =>
+    Task.spawn(function* () {
+      const data = yield* Memory.open()
+      const sync = yield* Sync.open(data.tree)
+      const service = yield* Service.open({
+        data,
+        sync,
+        blobs: yield* Blobs.open(),
+      })
+      const remote = yield* Remote.open({
+        url: new URL('memory:'),
+        fetch: service.fetch.bind(service),
+      })
+
+      const project = refer({ v: 0 })
+      const author = refer({ v: 1 })
+
+      const durable = yield* Memory.open()
+      const ephemeral = yield* Memory.open()
+
+      const local = Hybrid.from({ durable, ephemeral })
+
+      yield* data.transact([
+        { Assert: [project, 'name', 'synopsys'] },
+        { Assert: [project, 'version', '1.0.0'] },
+      ])
+
+      yield* local.transact([
+        { Assert: [project, 'author', author] },
+        { Assert: [author, 'name', 'Alice'] },
+      ])
+
+      const result = yield* local.merge(remote)
+
+      assert.deepEqual(result.local.hash, result.remote.hash, 'hashes match')
+    }),
+}


### PR DESCRIPTION
It got really messy, but here is a high level overview of the changes

- `differential.js` exports `differentiate` module that calculates a delta between local tree and remote tree that implements `PullSource` interface.
   - It also defines `SyncSource` and `SyncTarget` classes that adapt underlying tree reader and pull source to arguments expected by okra's `sync`  function.
     - This is largely fallout of okra library not being completely aligned with  it's own type defs.
     - Our implementations also use Task based interface in order to abstract sync / async sources.
- Service now **optional** takes `Sync.Service` that exposes synchronization protocol for `POST` requests with `accept: application/okra-sync` header.
- Sync protocol queues requests and processes them one at a time.
   - ℹ️ It is critical that db's aren't mutated during sync, otherwise one might encounter errors.
   - ⚠️ Either use `sync` protocol or legacy HTTP interface, using both would lead to errors as mutating db mid-sync will lead to problems.
   - 🏗️ We probably should split sync into push / pull jobs, because pulls could be paralleled and pushes need to be processed one at a time.